### PR TITLE
docs: add “internet-exposed self-hosted” hack (yes, it’s cursed)

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,8 @@ docker exec -it postgres psql -U postgres -d taxhacker -c "INSERT INTO users (id
 docker exec -it postgres psql -U postgres -d taxhacker -c "SELECT value FROM verification ORDER BY created_at DESC LIMIT 1;"
 ```
 
+5. Seed the DB. Becasuse we skipped the normal routed DB seeding won't happedn automatically. Open `<YOUR URL>/settings/danger` and click `[Reset fields, currencies and categories]`
+
 ## ⌨️ Local Development
 
 We use:

--- a/README.md
+++ b/README.md
@@ -164,6 +164,33 @@ You can also configure LLM provider settings in the application or via environme
 - **Google Gemini**: `GOOGLE_MODEL_NAME` and `GOOGLE_API_KEY`
 - **Mistral**: `MISTRAL_MODEL_NAME` and `MISTRAL_API_KEY`
 
+
+### 🌐 Internet-exposed self-hosted instance
+
+If you want to expose your instance to the internet and still keep it protected by built‑in login there is a hacky way to do so:
+
+1. Run with these env vars:
+
+   ```env
+   SELF_HOSTED_MODE=false
+   DISABLE_SIGNUP=true
+   BASE_URL=<URL you'll use to access Tax Hacker>
+   ```
+
+2. Create your user directly in the database (replace email as needed):
+
+```bash
+docker exec -it postgres psql -U postgres -d taxhacker -c "INSERT INTO users (id, email, name, membership_plan, is_email_verified, updated_at) VALUES ('6f5b4f8e-6f7a-4c3d-9b8b-7f2d2d61a9c3','mail@example.com','Owner','unlimited', true, now());"
+```
+
+3. Open your instance in the browser, click Sign In, and enter `mail@example.com`.
+
+4. Fetch the latest OTP from the DB and use it to sign in:
+
+```bash
+docker exec -it postgres psql -U postgres -d taxhacker -c "SELECT value FROM verification ORDER BY created_at DESC LIMIT 1;"
+```
+
 ## ⌨️ Local Development
 
 We use:

--- a/README.md
+++ b/README.md
@@ -164,34 +164,7 @@ You can also configure LLM provider settings in the application or via environme
 - **Google Gemini**: `GOOGLE_MODEL_NAME` and `GOOGLE_API_KEY`
 - **Mistral**: `MISTRAL_MODEL_NAME` and `MISTRAL_API_KEY`
 
-
-### 🌐 Internet-exposed self-hosted instance
-
-If you want to expose your instance to the internet and still keep it protected by built‑in login there is a hacky way to do so:
-
-1. Run with these env vars:
-
-   ```env
-   SELF_HOSTED_MODE=false
-   DISABLE_SIGNUP=true
-   BASE_URL=<URL you'll use to access Tax Hacker>
-   ```
-
-2. Create your user directly in the database (replace email as needed):
-
-```bash
-docker exec -it postgres psql -U postgres -d taxhacker -c "INSERT INTO users (id, email, name, membership_plan, is_email_verified, updated_at) VALUES ('6f5b4f8e-6f7a-4c3d-9b8b-7f2d2d61a9c3','mail@example.com','Owner','unlimited', true, now());"
-```
-
-3. Open your instance in the browser, click Sign In, and enter `mail@example.com`.
-
-4. Fetch the latest OTP from the DB and use it to sign in:
-
-```bash
-docker exec -it postgres psql -U postgres -d taxhacker -c "SELECT value FROM verification ORDER BY created_at DESC LIMIT 1;"
-```
-
-5. Seed the DB. Becasuse we skipped the normal routed DB seeding won't happedn automatically. Open `<YOUR URL>/settings/danger` and click `[Reset fields, currencies and categories]`
+> 💡 **Need internet access with authentication?** See [docs/self-hosted-public-access.md](docs/self-hosted-public-access.md) for a workaround (yes, it's cursed).
 
 ## ⌨️ Local Development
 

--- a/docs/self-hosted-public-access.md
+++ b/docs/self-hosted-public-access.md
@@ -1,0 +1,53 @@
+# Self-Hosted Public Access
+
+> ⚠️ **Warning: This is a workaround ("hack") for exposing self-hosted instances to the internet.**  
+> This approach has security implications and should be used with caution. For production deployments, consider implementing proper authentication with reverse proxy or using the official cloud version.
+
+## Overview
+
+By default, TaxHacker's self-hosted mode (`SELF_HOSTED_MODE=true`) disables the built-in authentication system, assuming the instance runs on a trusted local network or behind a reverse proxy with its own authentication.
+
+However, if you want to expose your self-hosted instance to the internet **and** still use TaxHacker's built-in login system, you can use this workaround.
+
+## How It Works
+
+The approach involves:
+
+1. Running TaxHacker with `SELF_HOSTED_MODE=false` (cloud mode)
+2. Manually creating a user via direct database access
+3. Retrieving the OTP (one-time password) from the database
+4. Using that OTP to sign in
+
+## Setup Instructions
+
+### 1. Configure Environment Variables
+
+Run with these environment variables:
+
+```env
+SELF_HOSTED_MODE=false
+DISABLE_SIGNUP=true
+BASE_URL=<URL you'll use to access TaxHacker>
+```
+
+### 2. Create a User Directly in the Database
+
+Create your user directly in the database (replace email as needed):
+
+```bash
+docker exec -it postgres psql -U postgres -d taxhacker -c "INSERT INTO users (id, email, name, membership_plan, is_email_verified, updated_at) VALUES ('6f5b4f8e-6f7a-4c3d-9b8b-7f2d2d61a9c3','mail@example.com','Owner','unlimited', true, now());"
+```
+
+### 3. Sign In with OTP from Database
+
+Open your instance in the browser, click Sign In, and enter your email address.
+
+Fetch the latest OTP from the database and use it to sign in:
+
+```bash
+docker exec -it postgres psql -U postgres -d taxhacker -c "SELECT value FROM verification ORDER BY created_at DESC LIMIT 1;"
+```
+
+### 4. Seed the Database
+
+Because we skipped the normal route, database seeding won't happen automatically. Open `<YOUR_URL>/settings/danger` and click `[Reset fields, currencies and categories]`


### PR DESCRIPTION
## What
Add README section showing how to expose a self-hosted instance and still use built‑in login. It’s hacky, but maybe usefull.

## How
`SELF_HOSTED_MODE=false`, insert a user via SQL, fetch OTP from DB, sign in.

## Why
Unblocks “public-ish” deployments without wiring full auth/reverse proxy. Cue the shame.

the change is **limited to docs; no code changes or migrations.**