### PR TITLE
Fix/custom fields accessibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,33 @@ You can also configure LLM provider settings in the application or via environme
 - **Google Gemini**: `GOOGLE_MODEL_NAME` and `GOOGLE_API_KEY`
 - **Mistral**: `MISTRAL_MODEL_NAME` and `MISTRAL_API_KEY`
 
+
+### 🌐 Internet-exposed self-hosted instance
+
+If you want to expose your instance to the internet and still keep it protected by built‑in login there is a hacky way to do so:
+
+1. Run with these env vars:
+
+   ```env
+   SELF_HOSTED_MODE=false
+   DISABLE_SIGNUP=true
+   BASE_URL=<URL you'll use to access Tax Hacker>
+   ```
+
+2. Create your user directly in the database (replace email as needed):
+
+```bash
+docker exec -it postgres psql -U postgres -d taxhacker -c "INSERT INTO users (id, email, name, membership_plan, is_email_verified, updated_at) VALUES ('6f5b4f8e-6f7a-4c3d-9b8b-7f2d2d61a9c3','mail@example.com','Owner','unlimited', true, now());"
+```
+
+3. Open your instance in the browser, click Sign In, and enter `mail@example.com`.
+
+4. Fetch the latest OTP from the DB and use it to sign in:
+
+```bash
+docker exec -it postgres psql -U postgres -d taxhacker -c "SELECT value FROM verification ORDER BY created_at DESC LIMIT 1;"
+```
+
 ## ⌨️ Local Development
 
 We use:

--- a/components/settings/crud.tsx
+++ b/components/settings/crud.tsx
@@ -52,6 +52,7 @@ export function CrudTable<T extends { [key: string]: any }>({ items, columns, on
         <input
           type="checkbox"
           checked={editingItem[column.key]}
+          aria-label={String(column.label)}
           onChange={(e) =>
             setEditingItem({
               ...editingItem,
@@ -65,6 +66,7 @@ export function CrudTable<T extends { [key: string]: any }>({ items, columns, on
         <select
           value={editingItem[column.key]}
           className="p-2 rounded-md border bg-transparent"
+          aria-label={String(column.label)}
           onChange={(e) =>
             setEditingItem({
               ...editingItem,
@@ -102,6 +104,7 @@ export function CrudTable<T extends { [key: string]: any }>({ items, columns, on
           <Input
             type="text"
             value={(editingItem[column.key] as string) || ""}
+            aria-label={String(column.label)}
             onChange={(e) =>
               setEditingItem({
                 ...editingItem,
@@ -118,6 +121,7 @@ export function CrudTable<T extends { [key: string]: any }>({ items, columns, on
       <Input
         type="text"
         value={editingItem[column.key] || ""}
+        aria-label={String(column.label)}
         onChange={(e) =>
           setEditingItem({
             ...editingItem,
@@ -134,6 +138,7 @@ export function CrudTable<T extends { [key: string]: any }>({ items, columns, on
         <input
           type="checkbox"
           checked={Boolean(newItem[column.key] || column.defaultValue)}
+          aria-label={String(column.label)}
           onChange={(e) =>
             setNewItem({
               ...newItem,
@@ -147,6 +152,7 @@ export function CrudTable<T extends { [key: string]: any }>({ items, columns, on
         <select
           value={String(newItem[column.key] || column.defaultValue || "")}
           className="p-2 rounded-md border bg-transparent"
+          aria-label={String(column.label)}
           onChange={(e) =>
             setNewItem({
               ...newItem,
@@ -181,24 +187,26 @@ export function CrudTable<T extends { [key: string]: any }>({ items, columns, on
               }
             />
           </div>
-            <Input
-              type="text"
-              value={String(newItem[column.key] || column.defaultValue || "")}
-              onChange={(e) =>
-                setNewItem({
-                  ...newItem,
-                  [column.key]: e.target.value,
-                })
-              }
-              placeholder="#FFFFFF"
-            />
-          </div>
+          <Input
+            type="text"
+            value={String(newItem[column.key] || column.defaultValue || "")}
+            aria-label={String(column.label)}
+            onChange={(e) =>
+              setNewItem({
+                ...newItem,
+                [column.key]: e.target.value,
+              })
+            }
+            placeholder="#FFFFFF"
+          />
+        </div>
       )
     }
     return (
       <Input
         type={column.type || "text"}
         value={String(newItem[column.key] || column.defaultValue || "")}
+        aria-label={String(column.label)}
         onChange={(e) =>
           setNewItem({
             ...newItem,


### PR DESCRIPTION
Fixes key accessibility gaps in custom field forms that were breaking screen reader support and semantic parsing:

### Changes
- **FormInput/FormTextarea**: Add `id` from `name` prop for proper `<label for="id">` association
- **FormSelect**: Add hidden input for form submission, `aria-labelledby` labeling, controlled/uncontrolled state sync (Radix Select compatibility)
- **CrudTable**: Add `aria-label` to inline inputs/selects/checkboxes in settings editor

### Why It Matters
- **AI Browser Support**: Semantic IDs/ARIA enable tools like Comet to parse and automate forms
- **Keyboard Navigation**: Full tab order with focus management
- **Form Reliability**: Select values submit correctly (no more lost data)
- **WCAG 2.1 AA Compliance**: Labels announce correctly (e.g., "Name, edit text" vs unlabeled)

### Testing
✅ Manually tested: Tab navigation, form submission, custom field editing  
✅ Comet Browser: dumped a huge promed so it will click throught everything
