### PR TITLE
Fix: Remove generateId: false to fix OTP email verification

### DIFF
--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -42,7 +42,6 @@ export const auth = betterAuth({
     },
   },
   advanced: {
-    generateId: false,
     cookiePrefix: "taxhacker",
   },
   plugins: [


### PR DESCRIPTION
⚠️ I'm aware the project is now focused on self-hosted deployments and OTP is not that inportant, but this is a small fix that resolves OTP login.

## Problem

OTP email verification fails with error: \`invalid input syntax for type uuid\` when Better Auth tries to create verification records using non-UUID strings as IDs.

## Root Cause

Setting \`advanced.generateId: false\` in Better Auth config conflicts with the \`email-otp\` plugin. When \`generateId: false\`, Better Auth attempts to use email strings directly as UUIDs for verification records, causing PostgreSQL UUID validation errors.

According to [Better Auth documentation](https://www.better-auth.com/docs/concepts/database), the \`generateId: false\` option should only be used when the database handles ID generation (e.g., auto-increment primary keys). For UUID-based schemas, Better Auth should generate UUIDs using \`crypto.randomUUID()\`.

## Solution

Remove the \`generateId: false\` line from \`lib/auth.ts\`. This allows Better Auth to properly generate UUIDs for all records, including email verification entries.

## Changes

- Removed \`generateId: false\` from the \`advanced\` configuration block
- No other changes required - the existing UUID schema works correctly with default Better Auth ID generation

## Testing

- ✅ OTP emails send successfully
- ✅ OTP verification completes without UUID errors
- ✅ User sessions created properly
- ✅ Existing authentication flows unaffected

## References

- Better Auth Database Config: https://www.better-auth.com/docs/concepts/database
- Related issue: https://www.linkedin.com/posts/dsujoy_typescript-betterauth-uuid-activity-7338559053310136320-J5fy