### PR TITLE
Improve docker-compose security defaults

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       - SELF_HOSTED_MODE=true
       - UPLOAD_PATH=/app/data/uploads
       - DATABASE_URL=postgresql://postgres:$POSTGRES_PASSWORD@postgres:5432/taxhacker
+      - BETTER_AUTH_SECRET=$BETTER_AUTH_SECRET
     volumes:
       - ./data:/app/data
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,12 +2,12 @@ services:
   app:
     image: ghcr.io/vas3k/taxhacker:latest
     ports:
-      - "7331:7331"
+      - "127.0.0.1:7331:7331"
     environment:
       - NODE_ENV=production
       - SELF_HOSTED_MODE=true
       - UPLOAD_PATH=/app/data/uploads
-      - DATABASE_URL=postgresql://postgres:postgres@postgres:5432/taxhacker
+      - DATABASE_URL=postgresql://postgres:$POSTGRES_PASSWORD@postgres:5432/taxhacker
     volumes:
       - ./data:/app/data
     restart: unless-stopped
@@ -18,12 +18,11 @@ services:
       options:
         max-size: "100M"
         max-file: "3"
-
   postgres:
     image: postgres:17-alpine
     environment:
       - POSTGRES_USER=postgres
-      - POSTGRES_PASSWORD=postgres
+      - POSTGRES_PASSWORD=$POSTGRES_PASSWORD
       - POSTGRES_DB=taxhacker
     volumes:
       - ./pgdata:/var/lib/postgresql/data


### PR DESCRIPTION
- Bind docker-compose port to 127.0.0.1 to avoid exposing the app on the LAN
- Require POSTGRES_PASSWORD to be provided instead of defaulting to `postgres`