### PR TITLE
fix(security): restrict CORS on progress SSE endpoint (#87)

### DIFF
--- a/app/api/progress/[progressId]/route.ts
+++ b/app/api/progress/[progressId]/route.ts
@@ -58,7 +58,6 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ prog
       "Content-Type": "text/event-stream",
       "Cache-Control": "no-cache, no-transform",
       Connection: "keep-alive",
-      "Access-Control-Allow-Origin": "*",
     },
   })
 }


### PR DESCRIPTION
## Summary
- Removes the wildcard `Access-Control-Allow-Origin: *` header from the progress SSE route
- Keeps the streaming headers required for same-origin `EventSource` usage

## Motivation
The progress endpoint returns user-scoped progress events for authenticated sessions. A wildcard CORS policy allows any origin to read those event-stream responses, which is broader than needed since the UI already connects via same-origin `/api/progress/...`.

Closes #87.

## Test plan
- [ ] Start the app and trigger a flow that uses progress updates (file analysis or export)
- [ ] Confirm progress updates still stream correctly in the UI
- [ ] Verify the response no longer includes `Access-Control-Allow-Origin: *`


Made with [Cursor](https://cursor.com)