### PR TITLE
ci: bump docker actions

### DIFF
--- a/.github/workflows/docker-latest.yml
+++ b/.github/workflows/docker-latest.yml
@@ -18,10 +18,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4.1.0
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4.2.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -29,14 +29,14 @@ jobs:
 
       - name: Extract metadata for Docker
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6.1.0
         with:
           images: ghcr.io/${{ github.repository_owner }}/taxhacker
           tags: |
             type=raw,value=latest
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7.2.0
         with:
           context: .
           push: true

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -18,10 +18,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4.1.0
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4.2.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -29,7 +29,7 @@ jobs:
 
       - name: Extract metadata for Docker
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6.1.0
         with:
           images: ghcr.io/${{ github.repository_owner }}/taxhacker
           tags: |
@@ -37,7 +37,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7.2.0
         with:
           context: .
           push: true


### PR DESCRIPTION
Bumps four GitHub Actions used in `docker-latest.yml`/`docker-release.yml`:

- `docker/setup-buildx-action` v3 → v4.1.0
- `docker/login-action` v3 → v4.2.0
- `docker/metadata-action` v5 → v6.1.0
- `docker/build-push-action` v6 → v7.2.0

Does not touch `actions/checkout`, which #76 already covers.