### PR TITLE
security(compose): add no-new-privileges and harden build/production compose files

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,12 @@ PORT=7331
 SELF_HOSTED_MODE=true
 DISABLE_SIGNUP=true
 
+# Required when using docker-compose.build.yml — set a strong, unique password.
+# The same value is used in DATABASE_URL, so update both together.
+POSTGRES_USER="postgres"
+POSTGRES_PASSWORD="change-me-to-a-strong-password"
+POSTGRES_DB="taxhacker"
+
 UPLOAD_PATH="./data/uploads"
 DATABASE_URL="postgresql://user@localhost:5432/taxhacker"
 

--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ The Docker Compose setup includes:
 - Automatic database migrations on startup
 - Volume mounts for persistent data storage
 - Production-ready configuration
+- `no-new-privileges` security option on all containers
 
 New Docker images are automatically built and published with every release. You can use specific version tags (e.g., `v1.0.0`) or `latest` for the most recent version.
 
@@ -165,6 +166,9 @@ Configure TaxHacker for your specific needs with these environment variables:
 | `SELF_HOSTED_MODE` | No | Set to "true" for self-hosting: enables auto-login, custom API keys, and additional features | `true` |
 | `DISABLE_SIGNUP` | No | Disable new user registration on your instance | `false` |
 | `BETTER_AUTH_SECRET` | Yes | Secret key for authentication (minimum 16 characters) | `your-secure-random-key` |
+| `POSTGRES_PASSWORD` | Yes (`docker-compose.build.yml`) | Password for the bundled Postgres when building locally — used in both `POSTGRES_PASSWORD` and `DATABASE_URL` | output of `openssl rand -hex 24` |
+| `POSTGRES_USER` | No (`docker-compose.build.yml`) | Database user (defaults to `postgres`) | `postgres` |
+| `POSTGRES_DB` | No (`docker-compose.build.yml`) | Database name (defaults to `taxhacker`) | `taxhacker` |
 
 
 ## ⌨️ Local Development

--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -4,15 +4,17 @@ services:
       context: .
       dockerfile: Dockerfile
     ports:
-      - "7331:7331"
+      - "127.0.0.1:7331:7331"
     environment:
       - NODE_ENV=production
       - SELF_HOSTED_MODE=true
       - UPLOAD_PATH=/app/data/uploads
-      - DATABASE_URL=postgresql://postgres:postgres@postgres:5432/taxhacker
+      - DATABASE_URL=postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-taxhacker}
     volumes:
       - ./data:/app/data
     restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
     logging:
       driver: "local"
       options:
@@ -27,9 +29,9 @@ services:
       - NODE_ENV=production
       - SELF_HOSTED_MODE=true
       - UPLOAD_PATH=/app/data/uploads
-      - DATABASE_URL=postgresql://postgres:postgres@postgres:5432/taxhacker
+      - DATABASE_URL=postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-taxhacker}
       # Must match the app's secret: it derives the key that decrypts stored mailbox passwords.
-      - BETTER_AUTH_SECRET=${BETTER_AUTH_SECRET}
+      - BETTER_AUTH_SECRET=${BETTER_AUTH_SECRET:?Set BETTER_AUTH_SECRET in your .env file}
     volumes:
       - ./data:/app/data
       - ./etc/crontab:/etc/cron.d/email-sync:ro
@@ -37,6 +39,8 @@ services:
     depends_on:
       - postgres
       - app
+    security_opt:
+      - no-new-privileges:true
     command: >
       sh -c "
         apt-get update && apt-get install -y cron &&
@@ -57,14 +61,16 @@ services:
     image: postgres:17-alpine
     container_name: taxhacker-postgres
     environment:
-      - POSTGRES_USER=postgres
-      - POSTGRES_PASSWORD=postgres
-      - POSTGRES_DB=taxhacker
+      - POSTGRES_USER=${POSTGRES_USER:-postgres}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in your .env file}
+      - POSTGRES_DB=${POSTGRES_DB:-taxhacker}
     volumes:
       - ./pgdata:/var/lib/postgresql/data
     restart: unless-stopped
     ports:
-      - "5432:5432"
+      - "127.0.0.1:5432:5432"
+    security_opt:
+      - no-new-privileges:true
     logging:
       driver: "local"
       options:

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -18,6 +18,8 @@ services:
       - "host.docker.internal:host-gateway"
     ports:
       - "127.0.0.1:7331:7331"
+    security_opt:
+      - no-new-privileges:true
     logging:
       driver: "json-file"
       options:
@@ -42,6 +44,8 @@ services:
     restart: unless-stopped
     depends_on:
       - app
+    security_opt:
+      - no-new-privileges:true
     command: >
       sh -c "
         apt-get update && apt-get install -y cron &&

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,8 @@ services:
     restart: unless-stopped
     depends_on:
       - postgres
+    security_opt:
+      - no-new-privileges:true
     logging:
       driver: "local"
       options:
@@ -27,7 +29,7 @@ services:
       - UPLOAD_PATH=/app/data/uploads
       - DATABASE_URL=postgresql://postgres:postgres@postgres:5432/taxhacker
       # Must match the app's secret: it derives the key that decrypts stored mailbox passwords.
-      - BETTER_AUTH_SECRET=${BETTER_AUTH_SECRET}
+      - BETTER_AUTH_SECRET=${BETTER_AUTH_SECRET:?Set BETTER_AUTH_SECRET in your .env file}
     volumes:
       - ./data:/app/data
       - ./etc/crontab:/etc/cron.d/email-sync:ro
@@ -35,6 +37,8 @@ services:
     depends_on:
       - postgres
       - app
+    security_opt:
+      - no-new-privileges:true
     command: >
       sh -c "
         apt-get update && apt-get install -y cron &&
@@ -60,6 +64,8 @@ services:
     volumes:
       - ./pgdata:/var/lib/postgresql/data
     restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
     logging:
       driver: "local"
       options:


### PR DESCRIPTION
Adds `security_opt: [no-new-privileges:true]` to all services across `docker-compose.yml`, `docker-compose.build.yml`, and `docker-compose.production.yml`.

For `docker-compose.build.yml` specifically, also binds ports to `127.0.0.1`, parametrizes `POSTGRES_USER`/`POSTGRES_PASSWORD`/`POSTGRES_DB`, and requires `POSTGRES_PASSWORD`/`BETTER_AUTH_SECRET` to be set (hard-fails via `${VAR:?msg}` rather than silently defaulting). `.env.example` and the README are updated to match.

Deliberately does not touch `docker-compose.yml`'s port binding or `POSTGRES_PASSWORD` - #96 already covers those.

FWIW: portainer ignores default-variable substitutions such as `${POSTGRES_USER:-postgres}`