### PR TITLE
chore(deps): bump TypeScript to v6

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,30 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-added-large-files
+      - id: check-merge-conflict
+
+  - repo: local
+    hooks:
+      - id: lint
+        name: ESLint
+        entry: npm run lint
+        language: system
+        pass_filenames: false
+        types: [ts, tsx]
+      - id: typecheck
+        name: TypeScript Type Check
+        entry: npx tsc --noEmit
+        language: system
+        pass_filenames: false
+        types: [ts, tsx]
+      - id: test
+        name: Tests
+        entry: npm run test
+        language: system
+        pass_filenames: false
+        stages: [pre-push]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:23-slim AS base
+FROM node:26-slim AS base
 
 # Default environment variables
 ENV PORT=7331

--- a/ai/providers/llmProvider.ts
+++ b/ai/providers/llmProvider.ts
@@ -2,6 +2,7 @@ import { ChatOpenAI } from "@langchain/openai"
 import { ChatGoogleGenerativeAI } from "@langchain/google-genai"
 import { ChatMistralAI } from "@langchain/mistralai"
 import { BaseMessage, HumanMessage } from "@langchain/core/messages"
+import type { AnalyzeAttachment } from "@/ai/attachments"
 
 export type LLMProvider = "openai" | "google" | "mistral" | "openai_compatible"
 
@@ -19,7 +20,7 @@ export interface LLMSettings {
 export interface LLMRequest {
   prompt: string
   schema?: Record<string, unknown>
-  attachments?: any[]
+  attachments?: AnalyzeAttachment[]
 }
 
 export interface LLMResponse {
@@ -29,10 +30,29 @@ export interface LLMResponse {
   error?: string
 }
 
+type LLMModel = ChatOpenAI | ChatGoogleGenerativeAI | ChatMistralAI
+
+type MessageContent = Array<{ type: string; text?: string; image_url?: { url: string } }>
+
+function extractErrorInfo(error: unknown): {
+  message: string | undefined
+  cause: unknown
+  status: number | undefined
+  errorBody: unknown
+} {
+  const obj = error as Record<string, unknown>
+  return {
+    message: typeof obj?.message === "string" ? obj.message : undefined,
+    cause: obj?.cause,
+    status: obj?.status as number | undefined,
+    errorBody: obj?.error,
+  }
+}
+
 async function requestLLMUnified(config: LLMConfig, req: LLMRequest): Promise<LLMResponse> {
   try {
     const temperature = 0
-    let model: any
+    let model: LLMModel
     if (config.provider === "openai") {
       model = new ChatOpenAI({
         apiKey: config.apiKey,
@@ -68,7 +88,7 @@ async function requestLLMUnified(config: LLMConfig, req: LLMRequest): Promise<LL
       }
     }
 
-    let message_content: any = [{ type: "text", text: req.prompt }]
+    const messageContent: MessageContent = [{ type: "text", text: req.prompt }]
     if (req.attachments && req.attachments.length > 0) {
       const images = req.attachments.map((att) => ({
         type: "image_url",
@@ -76,29 +96,142 @@ async function requestLLMUnified(config: LLMConfig, req: LLMRequest): Promise<LL
           url: `data:${att.contentType};base64,${att.base64}`,
         },
       }))
-      message_content.push(...images)
+      messageContent.push(...images)
     }
-    const messages: BaseMessage[] = [new HumanMessage({ content: message_content })]
+    const messages: BaseMessage[] = [new HumanMessage({ content: messageContent })]
 
-    let response: any
+    let response: Record<string, unknown>
     if (config.provider === "openai_compatible") {
       const raw = await model.invoke(messages)
-      const text = typeof raw.content === "string" ? raw.content : raw.content.map((c: any) => c.text || "").join("")
+      const rawContent = raw as { content: string | Array<{ text?: string }> }
+      const text = typeof rawContent.content === "string"
+        ? rawContent.content
+        : Array.isArray(rawContent.content)
+          ? rawContent.content.map((c: { text?: string }) => c.text || "").join("")
+          : ""
       response = JSON.parse(text.replace(/```(?:json)?\s*/g, "").trim())
     } else {
-      const structuredModel = model.withStructuredOutput(req.schema, { name: "transaction" })
-      response = await structuredModel.invoke(messages)
+      const structuredModel = model.withStructuredOutput(req.schema!, { name: "transaction" })
+      response = await structuredModel.invoke(messages) as Record<string, unknown>
     }
 
     return {
-      output: response,
+      output: response as Record<string, string>,
       provider: config.provider,
     }
-  } catch (error: any) {
+  } catch (error: unknown) {
+    const info = extractErrorInfo(error)
+    const causeMsg = info.cause instanceof Error ? info.cause.message : info.cause ? String(info.cause) : null
+    const status = info.status ? ` (HTTP ${info.status})` : ""
+    const body = info.errorBody ? ` ${JSON.stringify(info.errorBody)}` : ""
+    const detail = [
+      info.message ?? `${config.provider} request failed`,
+      causeMsg && causeMsg !== info.message ? `cause: ${causeMsg}` : null,
+    ].filter(Boolean).join(" | ")
+
+    console.error(`[${config.provider}] LLM request failed${status}:`, {
+      message: info.message,
+      status: info.status,
+      cause: info.cause ?? undefined,
+      ...(info.errorBody ? { body: info.errorBody } : {}),
+    })
+
+    const isVisionError =
+      detail.includes("content.type") ||
+      (detail.includes("image_url") && detail.includes("not supported"))
+
+    const visionHint = isVisionError
+      ? " — This model does not support image input. Use a vision-capable model or test the provider in Settings."
+      : ""
+
     return {
       output: {},
       provider: config.provider,
-      error: error instanceof Error ? error.message : `${config.provider} request failed`,
+      error: `${detail}${status}${body}${visionHint}`,
+    }
+  }
+}
+
+export interface LLMTestResult {
+  success: boolean
+  supportsVision: boolean
+  message: string
+}
+
+const TINY_TEST_IMAGE_BASE64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg=="
+
+export async function testLLMProvider(config: LLMConfig): Promise<LLMTestResult> {
+  try {
+    const temperature = 0
+    let model: LLMModel
+    if (config.provider === "openai") {
+      model = new ChatOpenAI({ apiKey: config.apiKey, model: config.model, temperature })
+    } else if (config.provider === "google") {
+      model = new ChatGoogleGenerativeAI({ apiKey: config.apiKey, model: config.model, temperature })
+    } else if (config.provider === "mistral") {
+      model = new ChatMistralAI({ apiKey: config.apiKey, model: config.model, temperature })
+    } else if (config.provider === "openai_compatible") {
+      model = new ChatOpenAI({
+        apiKey: config.apiKey || "not-needed",
+        model: config.model,
+        temperature,
+        configuration: { baseURL: config.baseUrl?.trim() },
+      })
+    } else {
+      return { success: false, supportsVision: false, message: `Unknown provider: ${config.provider}` }
+    }
+
+    const messages: BaseMessage[] = [
+      new HumanMessage({
+        content: [
+          { type: "text", text: "Reply with the single word: ok" },
+          { type: "image_url", image_url: { url: `data:image/png;base64,${TINY_TEST_IMAGE_BASE64}` } },
+        ],
+      }),
+    ]
+
+    const raw = await model.invoke(messages)
+    const rawContent = raw as { content: string | Array<{ text?: string }> }
+    const text =
+      typeof rawContent.content === "string"
+        ? rawContent.content
+        : Array.isArray(rawContent.content)
+          ? rawContent.content.map((c: { text?: string }) => c.text || "").join("")
+          : ""
+
+    return {
+      success: true,
+      supportsVision: true,
+      message: `Model responded: "${text.trim().slice(0, 100)}"`,
+    }
+  } catch (error: unknown) {
+    const causeMsg =
+      error instanceof Error && error.cause instanceof Error
+        ? error.cause.message
+        : (error as Record<string, unknown>)?.cause
+          ? String((error as Record<string, unknown>).cause)
+          : null
+    const errorMsg = error instanceof Error ? error.message : String(error)
+    const combined = [errorMsg, causeMsg].filter(Boolean).join(" | ")
+
+    const isVisionRejection =
+      combined.includes("content.type") ||
+      combined.includes("image_url") ||
+      (combined.includes("image") && combined.includes("not supported"))
+
+    if (isVisionRejection) {
+      return {
+        success: false,
+        supportsVision: false,
+        message: "This model does not support image input. Invoice analysis requires a vision-capable model.",
+      }
+    }
+
+    return {
+      success: false,
+      supportsVision: false,
+      message: `Connection failed: ${combined}`,
     }
   }
 }

--- a/app/(app)/apps/email/components/email-server-manager.tsx
+++ b/app/(app)/apps/email/components/email-server-manager.tsx
@@ -23,10 +23,10 @@ const getDefaultAppData = (): EmailAppData => ({
   },
 })
 
-export function EmailServerManager({ user, settings, appData }: EmailServerManagerProps) {
+export function EmailServerManager({ appData }: EmailServerManagerProps) {
   const data = appData || getDefaultAppData()
   const [editingServer, setEditingServer] = useState<EmailServer | null>(null)
-  const [isPending, startTransition] = useTransition()
+  const [isPending] = useTransition()
 
   return (
     <div className="space-y-6">

--- a/app/(app)/apps/invoices/actions.ts
+++ b/app/(app)/apps/invoices/actions.ts
@@ -1,5 +1,6 @@
 "use server"
 
+import * as React from "react"
 import { getCurrentUser, isSubscriptionExpired } from "@/lib/auth"
 import {
   getTransactionFileUploadPath,
@@ -29,7 +30,7 @@ import { InvoiceAppData } from "./page"
 
 export async function generateInvoicePDF(data: InvoiceFormData): Promise<Uint8Array> {
   const pdfElement = createElement(InvoicePDF, { data })
-  const buffer = await renderToBuffer(pdfElement as any)
+  const buffer = await renderToBuffer(pdfElement as unknown as React.ReactElement<Record<string, never>>)
   return new Uint8Array(buffer)
 }
 

--- a/app/(app)/apps/invoices/components/invoice-generator.tsx
+++ b/app/(app)/apps/invoices/components/invoice-generator.tsx
@@ -115,7 +115,7 @@ export function InvoiceGenerator({
       const pdfBuffer = await generateInvoicePDF(formData)
 
       // Create a blob from the buffer
-      const blob = new Blob([pdfBuffer], { type: "application/pdf" })
+      const blob = new Blob([pdfBuffer as BlobPart], { type: "application/pdf" })
 
       // Create a URL for the blob
       const url = URL.createObjectURL(blob)

--- a/app/(app)/apps/invoices/components/invoice-generator.tsx
+++ b/app/(app)/apps/invoices/components/invoice-generator.tsx
@@ -82,7 +82,7 @@ export function InvoiceGenerator({
 }) {
   const templates: InvoiceTemplate[] = useMemo(
     () => [...defaultTemplates(user, settings), ...(appData?.templates || [])],
-    [appData]
+    [user, settings, appData]
   )
 
   const [selectedTemplate, setSelectedTemplate] = useState<string>(templates[0].name)
@@ -222,7 +222,7 @@ export function InvoiceGenerator({
             <Button
               variant={selectedTemplate === template.name ? "default" : "outline"}
               className={`
-                  whitespace-nowrap p-4 
+                  whitespace-nowrap p-4
                   ${selectedTemplate === template.name ? "bg-black hover:bg-gray-900" : "border-gray-300 text-gray-700 hover:bg-gray-100"}
                 `}
               onClick={() => handleTemplateSelect(template.name)}

--- a/app/(app)/apps/invoices/components/invoice-generator.tsx
+++ b/app/(app)/apps/invoices/components/invoice-generator.tsx
@@ -16,9 +16,9 @@ import {
 } from "../actions"
 import defaultTemplates, { InvoiceTemplate } from "../default-templates"
 import { InvoiceAppData } from "../page"
-import { InvoiceFormData, InvoicePage } from "./invoice-page"
+import { InvoiceFormAction, InvoiceFormData, InvoicePage } from "./invoice-page"
 
-function invoiceFormReducer(state: InvoiceFormData, action: any): InvoiceFormData {
+function invoiceFormReducer(state: InvoiceFormData, action: InvoiceFormAction): InvoiceFormData {
   switch (action.type) {
     case "SET_FORM":
       return action.payload

--- a/app/(app)/apps/invoices/components/invoice-page.tsx
+++ b/app/(app)/apps/invoices/components/invoice-page.tsx
@@ -53,9 +53,23 @@ export interface InvoiceFormData {
   summaryTotalLabel: string
 }
 
+export type InvoiceFormAction =
+  | { type: "SET_FORM"; payload: InvoiceFormData }
+  | { type: "UPDATE_FIELD"; field: string; value: string | number | boolean | null }
+  | { type: "ADD_ITEM" }
+  | { type: "UPDATE_ITEM"; index: number; field: string; value: string | number | boolean }
+  | { type: "REMOVE_ITEM"; index: number }
+  | { type: "ADD_TAX" }
+  | { type: "UPDATE_TAX"; index: number; field: string; value: string | number }
+  | { type: "REMOVE_TAX"; index: number }
+  | { type: "ADD_FEE" }
+  | { type: "UPDATE_FEE"; index: number; field: string; value: string | number }
+  | { type: "REMOVE_FEE"; index: number }
+  | { type: "UPDATE_SETTING"; field: string; value: string }
+
 interface InvoicePageProps {
   invoiceData: InvoiceFormData
-  dispatch: React.Dispatch<any>
+  dispatch: React.Dispatch<InvoiceFormAction>
   currencies: Currency[]
 }
 

--- a/app/(app)/apps/invoices/components/invoice-pdf.tsx
+++ b/app/(app)/apps/invoices/components/invoice-pdf.tsx
@@ -307,6 +307,7 @@ export function InvoicePDF({ data }: { data: InvoiceFormData }): ReactElement {
             </View>
             {data.businessLogo && (
               <View style={styles.headerRight}>
+                {/* eslint-disable-next-line jsx-a11y/alt-text -- react-pdf's Image has no alt prop, this isn't an HTML img */}
                 <Image src={data.businessLogo} style={styles.logo} />
               </View>
             )}

--- a/app/(app)/export/transactions/route.ts
+++ b/app/(app)/export/transactions/route.ts
@@ -175,7 +175,7 @@ export async function GET(request: Request) {
       },
     })
 
-    return new NextResponse(zipContent, {
+    return new NextResponse(zipContent as BodyInit, {
       headers: {
         "Content-Type": "application/zip",
         "Content-Disposition": `attachment; filename="transactions.zip"`,

--- a/app/(app)/export/transactions/route.ts
+++ b/app/(app)/export/transactions/route.ts
@@ -69,7 +69,7 @@ export async function GET(request: Request) {
 
     if (!includeAttachments) {
       const stream = Readable.from(csvStream)
-      return new NextResponse(stream as any, {
+      return new NextResponse(stream as unknown as BodyInit, {
         headers: {
           "Content-Type": "text/csv",
           "Content-Disposition": `attachment; filename="transactions.csv"`,

--- a/app/(app)/files/actions.ts
+++ b/app/(app)/files/actions.ts
@@ -25,7 +25,7 @@ export async function uploadFilesAction(formData: FormData): Promise<ActionState
   }
 
   // Process each file
-  const uploadedFiles = await Promise.all(
+  await Promise.all(
     files.map(async (file) => {
       if (!(file instanceof File)) {
         return { success: false, error: "Invalid file" }

--- a/app/(auth)/cloud/payment/success/page.tsx
+++ b/app/(auth)/cloud/payment/success/page.tsx
@@ -4,7 +4,6 @@ import { Card, CardContent, CardDescription, CardFooter, CardTitle } from "@/com
 import { ColoredText } from "@/components/ui/colored-text"
 import config from "@/lib/config"
 import { PLANS, stripeClient } from "@/lib/stripe"
-import { createUserDefaults, isDatabaseEmpty } from "@/models/defaults"
 import { getOrCreateCloudUser } from "@/models/users"
 import { Cake, Ghost } from "lucide-react"
 import Link from "next/link"

--- a/app/api/email/sync/route.ts
+++ b/app/api/email/sync/route.ts
@@ -2,7 +2,7 @@ import { fetchEmails } from "@/app/(app)/apps/email/scripts/fetch-emails"
 import { getCurrentUser } from "@/lib/auth"
 import { NextRequest, NextResponse } from "next/server"
 
-export async function POST(request: NextRequest) {
+export async function POST(_request: NextRequest) {
   try {
     // Verify user is authenticated
     const user = await getCurrentUser()
@@ -33,7 +33,7 @@ export async function POST(request: NextRequest) {
   }
 }
 
-export async function GET(request: NextRequest) {
+export async function GET(_request: NextRequest) {
   try {
     // Verify user is authenticated
     const user = await getCurrentUser()
@@ -47,7 +47,7 @@ export async function GET(request: NextRequest) {
       methods: ["POST"],
       description: "Trigger manual email synchronization",
     })
-  } catch (error) {
+  } catch (_error) {
     return NextResponse.json({ error: "Failed to get sync status" }, { status: 500 })
   }
 }

--- a/app/api/progress/[progressId]/route.ts
+++ b/app/api/progress/[progressId]/route.ts
@@ -20,7 +20,7 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ prog
   const encoder = new TextEncoder()
   const stream = new ReadableStream({
     async start(controller) {
-      let lastSent: any = null
+      let lastSent: unknown = null
       let stopped = false
 
       req.signal.addEventListener("abort", () => {

--- a/app/api/stripe/webhook/route.ts
+++ b/app/api/stripe/webhook/route.ts
@@ -1,6 +1,5 @@
 import config from "@/lib/config"
 import { PLANS, stripeClient } from "@/lib/stripe"
-import { createUserDefaults, isDatabaseEmpty } from "@/models/defaults"
 import { getOrCreateCloudUser, getUserByStripeCustomerId, updateUser } from "@/models/users"
 import { NextResponse } from "next/server"
 import Stripe from "stripe"

--- a/app/docs/ai/page.tsx
+++ b/app/docs/ai/page.tsx
@@ -68,7 +68,7 @@ export default async function AI() {
       </p>
       <p className="text-gray-700 leading-relaxed mb-6">
         We store <strong>structured outputs</strong> from the AI (e.g., parsed fields, categorization) in your account
-        for future use. We do <strong>not</strong> store raw AI prompts or responses beyond what's necessary to populate
+        for future use. We do <strong>not</strong> store raw AI prompts or responses beyond what&#39;s necessary to populate
         your data.
       </p>
 

--- a/app/docs/cookie/page.tsx
+++ b/app/docs/cookie/page.tsx
@@ -128,7 +128,7 @@ export default async function Cookie() {
       <h2 className="text-2xl font-semibold text-slate-800 mb-4">5. Updates to This Policy</h2>
       <p className="text-slate-700 mb-6 leading-relaxed">
         We may update this Cookie Policy from time to time. The latest version will always be available on this page,
-        with the "Effective Date" updated accordingly.
+        with the &quot;Effective Date&quot; updated accordingly.
       </p>
 
       <h2 className="text-2xl font-semibold text-slate-800 mb-4">6. Contact</h2>

--- a/app/docs/privacy_policy/page.tsx
+++ b/app/docs/privacy_policy/page.tsx
@@ -190,7 +190,7 @@ export default async function PrivacyPolicy() {
       <hr className="my-8 border-slate-200" />
 
       <h3 className="text-2xl font-semibold text-slate-800 mb-4">
-        9. <strong>Children's Privacy</strong>
+        9. <strong>Children&#39;s Privacy</strong>
       </h3>
       <p className="text-slate-700 mb-6 leading-relaxed">
         TaxHacker is <strong className="text-slate-800">not intended for users under the age of 18</strong>. We do not

--- a/app/docs/terms/page.tsx
+++ b/app/docs/terms/page.tsx
@@ -152,7 +152,7 @@ export default async function Terms() {
 
       <h2 className="text-2xl font-semibold text-slate-800 mb-4">10. Changes to These Terms</h2>
       <p className="text-slate-700 mb-6 leading-relaxed">
-        We may revise these Terms at any time. If we make material changes, we'll notify users via email or in-app
+        We may revise these Terms at any time. If we make material changes, we&#39;ll notify users via email or in-app
         notification. Continued use after changes constitutes acceptance of the new Terms.
       </p>
     </div>

--- a/app/landing/landing.tsx
+++ b/app/landing/landing.tsx
@@ -306,7 +306,7 @@ export default function LandingPage() {
                 </li>
                 <li className="flex items-center">
                   <span className="text-orange-600 mr-3 text-lg">📤</span>
-                  Download full data archive to migrate to another service. We don't take away or limit what you do with
+                  Download full data archive to migrate to another service. We don&#39;t take away or limit what you do with
                   your data
                 </li>
               </ul>
@@ -377,7 +377,7 @@ export default function LandingPage() {
               <ul className="space-y-3 text-gray-700 mb-8">
                 <li className="flex items-center">
                   <span className="text-purple-600 mr-3 text-lg">🎯</span>
-                  SaaS version if you don't want to hassle with own servers and deployments
+                  SaaS version if you don&#39;t want to hassle with own servers and deployments
                 </li>
                 <li className="flex items-center">
                   <span className="text-purple-600 mr-3 text-lg">🤖</span>

--- a/components/agents/currency-converter.tsx
+++ b/components/agents/currency-converter.tsx
@@ -64,10 +64,16 @@ export const CurrencyConverterTool = ({
 
   useEffect(() => {
     fetchAndUpdateRates()
+    // fetchAndUpdateRates is intentionally omitted: it's redefined every render and only
+    // needs to re-run when the values below actually change, not on every re-render.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [originalCurrencyCode, targetCurrencyCode, normalizedDateString, originalTotal])
 
   useEffect(() => {
     onChange?.(convertedTotal)
+    // onChange is intentionally omitted: callers often pass a new inline function each
+    // render, which would otherwise cause this effect to fire on every render.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [convertedTotal])
 
   if (!originalTotal || !originalCurrencyCode || !targetCurrencyCode || originalCurrencyCode === targetCurrencyCode) {

--- a/components/agents/currency-converter.tsx
+++ b/components/agents/currency-converter.tsx
@@ -94,7 +94,9 @@ export const CurrencyConverterTool = ({
               value={convertedTotal}
               onChange={(e) => {
                 const newValue = parseFloat(e.target.value || "0")
-                !isNaN(newValue) && setConvertedTotal(Math.round(newValue * 100) / 100)
+                if (!isNaN(newValue)) {
+                  setConvertedTotal(Math.round(newValue * 100) / 100)
+                }
               }}
               className="w-32 rounded-md border border-input px-2 py-1"
             />

--- a/components/agents/items-detect.tsx
+++ b/components/agents/items-detect.tsx
@@ -1,5 +1,5 @@
 import { formatCurrency } from "@/lib/utils"
-import { Save, Split } from "lucide-react"
+import { Split } from "lucide-react"
 import { Button } from "../ui/button"
 import { TransactionData } from "@/models/transactions"
 import { splitFileIntoItemsAction } from "@/app/(app)/unsorted/actions"

--- a/components/dashboard/income-expense-graph.tsx
+++ b/components/dashboard/income-expense-graph.tsx
@@ -109,8 +109,8 @@ export function IncomeExpenseGraph({ data, defaultCurrency }: IncomeExpenseGraph
         <div className="h-full flex flex-col" style={{ minWidth: `${Math.max(600, data.length * 94)}px` }}>
           {/* Income section (top half) */}
           <div className="h-1/2 flex justify-center gap-1 px-2">
-            {data.map((item, index) => {
-              const incomeHeight = maxValue > 0 ? (item.income / maxValue) * 100 : 0
+            {data.map((item) => {
+               const incomeHeight = maxValue > 0 ? (item.income / maxValue) * 100 : 0
 
               return (
                 <div
@@ -148,8 +148,8 @@ export function IncomeExpenseGraph({ data, defaultCurrency }: IncomeExpenseGraph
 
           {/* Expense section (bottom half) */}
           <div className="h-1/2 flex justify-center gap-1 px-2">
-            {data.map((item, index) => {
-              const expenseHeight = maxValue > 0 ? (item.expenses / maxValue) * 100 : 0
+            {data.map((item) => {
+               const expenseHeight = maxValue > 0 ? (item.expenses / maxValue) * 100 : 0
 
               return (
                 <div

--- a/components/forms/simple.tsx
+++ b/components/forms/simple.tsx
@@ -265,6 +265,9 @@ export const FormAvatar = ({
       <div className={cn("relative group", className)}>
         <div className="absolute inset-0 flex items-center justify-center bg-background rounded-lg overflow-hidden">
           {preview ? (
+            // next/image doesn't support arbitrary user-uploaded data/blob URLs without
+            // extra config; this is a lightweight client-side avatar preview.
+            // eslint-disable-next-line @next/next/no-img-element
             <img src={preview} alt="Avatar preview" className="w-full h-full object-cover" />
           ) : (
             <div className="w-full h-full bg-muted flex items-center justify-center">

--- a/components/settings/crud.tsx
+++ b/components/settings/crud.tsx
@@ -310,9 +310,9 @@ export function CrudTable<T extends Record<string, unknown>>({ items, columns, o
                         </Button>
                       )}
                       {item.isDeletable && (
-                        <Button 
-                          variant="ghost" 
-                          size="icon" 
+                        <Button
+                          variant="ghost"
+                          size="icon"
                           onClick={() => handleDelete((item.code || item.id) as string)}
                           aria-label={`Delete ${String(item.name || item.code || 'item')}`}
                         >

--- a/components/settings/crud.tsx
+++ b/components/settings/crud.tsx
@@ -23,12 +23,12 @@ interface CrudProps<T> {
   onEdit?: (id: string, data: Partial<T>) => Promise<{ success: boolean; error?: string }>
 }
 
-export function CrudTable<T extends { [key: string]: any }>({ items, columns, onDelete, onAdd, onEdit }: CrudProps<T>) {
+export function CrudTable<T extends Record<string, unknown>>({ items, columns, onDelete, onAdd, onEdit }: CrudProps<T>) {
   const [isAdding, setIsAdding] = useState(false)
   const [editingId, setEditingId] = useState<string | null>(null)
   const [newItem, setNewItem] = useState<Partial<T>>(itemDefaults(columns))
   const [editingItem, setEditingItem] = useState<Partial<T>>(itemDefaults(columns))
-  const [optimisticItems, addOptimisticItem] = useOptimistic(items, (state, newItem: T) => [...state, newItem])
+  const [optimisticItems, _addOptimisticItem] = useOptimistic(items, (state, newItem: T) => [...state, newItem])
 
   const FormCell = (item: T, column: CrudColumn<T>) => {
     if (column.type === "checkbox") {
@@ -43,7 +43,7 @@ export function CrudTable<T extends { [key: string]: any }>({ items, columns, on
         </div>
       )
     }
-    return item[column.key]
+    return item[column.key] as React.ReactNode
   }
 
   const EditFormCell = (item: T, column: CrudColumn<T>) => {
@@ -51,7 +51,7 @@ export function CrudTable<T extends { [key: string]: any }>({ items, columns, on
       return (
         <input
           type="checkbox"
-          checked={editingItem[column.key]}
+          checked={Boolean(editingItem[column.key])}
           aria-label={String(column.label)}
           onChange={(e) =>
             setEditingItem({
@@ -64,7 +64,7 @@ export function CrudTable<T extends { [key: string]: any }>({ items, columns, on
     } else if (column.type === "select") {
       return (
         <select
-          value={editingItem[column.key]}
+          value={editingItem[column.key] as string}
           className="p-2 rounded-md border bg-transparent"
           aria-label={String(column.label)}
           onChange={(e) =>
@@ -120,7 +120,7 @@ export function CrudTable<T extends { [key: string]: any }>({ items, columns, on
     return (
       <Input
         type="text"
-        value={editingItem[column.key] || ""}
+        value={(editingItem[column.key] as string) || ""}
         aria-label={String(column.label)}
         onChange={(e) =>
           setEditingItem({
@@ -247,7 +247,7 @@ export function CrudTable<T extends { [key: string]: any }>({ items, columns, on
   }
 
   const startEditing = (item: T) => {
-    setEditingId(item.code || item.id)
+    setEditingId((item.code || item.id) as string)
     setEditingItem(item)
   }
 
@@ -287,7 +287,7 @@ export function CrudTable<T extends { [key: string]: any }>({ items, columns, on
                 <div className="flex gap-2">
                   {editingId === (item.code || item.id) ? (
                     <>
-                      <Button size="sm" onClick={() => handleEdit(item.code || item.id)} aria-label="Save changes">
+                      <Button size="sm" onClick={() => handleEdit((item.code || item.id) as string)} aria-label="Save changes">
                         Save
                       </Button>
                       <Button size="sm" variant="outline" onClick={() => setEditingId(null)} aria-label="Cancel editing">
@@ -313,7 +313,7 @@ export function CrudTable<T extends { [key: string]: any }>({ items, columns, on
                         <Button 
                           variant="ghost" 
                           size="icon" 
-                          onClick={() => handleDelete(item.code || item.id)}
+                          onClick={() => handleDelete((item.code || item.id) as string)}
                           aria-label={`Delete ${String(item.name || item.code || 'item')}`}
                         >
                           <Trash2 />

--- a/components/settings/llm-settings-form.tsx
+++ b/components/settings/llm-settings-form.tsx
@@ -152,11 +152,10 @@ function DndProviderBlocks({
   return (
     <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
       <SortableContext items={providerOrder} strategy={verticalListSortingStrategy}>
-        {providerOrder.map((providerKey, idx) => (
+        {providerOrder.map((providerKey) => (
           <SortableProviderBlock
             key={providerKey}
             id={providerKey}
-            idx={idx}
             providerKey={providerKey}
             value={providerValues[providerKey]}
             handleValueChange={handleProviderValueChange}
@@ -169,13 +168,12 @@ function DndProviderBlocks({
 
 type SortableProviderBlockProps = {
   id: string
-  idx: number
   providerKey: string
   value: { apiKey: string; model: string; baseUrl: string }
   handleValueChange: (providerKey: string, field: "apiKey" | "model" | "baseUrl", value: string) => void
 }
 
-function SortableProviderBlock({ id, idx, providerKey, value, handleValueChange }: SortableProviderBlockProps) {
+function SortableProviderBlock({ id, providerKey, value, handleValueChange }: SortableProviderBlockProps) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id })
 
   const provider = PROVIDERS.find((p) => p.key === providerKey)

--- a/components/transactions/edit.tsx
+++ b/components/transactions/edit.tsx
@@ -56,7 +56,7 @@ export default function TransactionEditForm({
         acc[field.code] = transaction.extra?.[field.code as keyof typeof transaction.extra] || ""
         return acc
       },
-      {} as Record<string, any>
+      {} as Record<string, unknown>
     ),
   })
 

--- a/components/transactions/filters.tsx
+++ b/components/transactions/filters.tsx
@@ -21,7 +21,7 @@ export function TransactionSearchAndFilters({
 }) {
   const [filters, setFilters] = useTransactionFilters()
 
-  const handleFilterChange = (name: keyof TransactionFilters, value: any) => {
+  const handleFilterChange = (name: keyof TransactionFilters, value: string | number | boolean | undefined) => {
     setFilters((prev) => ({
       ...prev,
       [name]: value,
@@ -86,8 +86,8 @@ export function TransactionSearchAndFilters({
             to: filters.dateTo ? new Date(filters.dateTo) : undefined,
           }}
           onChange={(date) => {
-            handleFilterChange("dateFrom", date ? date.from : undefined)
-            handleFilterChange("dateTo", date ? date.to : undefined)
+            handleFilterChange("dateFrom", date?.from ? date.from.toISOString() : undefined)
+            handleFilterChange("dateTo", date?.to ? date.to.toISOString() : undefined)
           }}
         />
 

--- a/components/transactions/list.tsx
+++ b/components/transactions/list.tsx
@@ -263,6 +263,10 @@ export function TransactionList({ transactions, fields = [] }: { transactions: T
       params.delete("ordering")
     }
     router.push(`/transactions?${params.toString()}`)
+    // router and searchParams are intentionally omitted: including searchParams would
+    // re-run this effect after every router.push it triggers, since navigation produces
+    // a new searchParams object each time.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [sorting])
 
   const getSortIcon = (field: string) => {

--- a/components/transactions/list.tsx
+++ b/components/transactions/list.tsx
@@ -12,12 +12,14 @@ import { ArrowDownIcon, ArrowUpIcon, File } from "lucide-react"
 import { useRouter, useSearchParams } from "next/navigation"
 import { useEffect, useMemo, useState } from "react"
 
+type TransactionWithRelations = Transaction & { project?: Project; category?: Category }
+
 type FieldRenderer = {
   name: string
   code: string
   classes?: string
   sortable: boolean
-  formatValue?: (transaction: Transaction & any) => React.ReactNode
+  formatValue?: (transaction: TransactionWithRelations) => React.ReactNode
   footerValue?: (transactions: Transaction[]) => React.ReactNode
 }
 
@@ -50,7 +52,7 @@ export const standardFieldRenderers: Record<string, FieldRenderer> = {
     name: "Project",
     code: "projectCode",
     sortable: true,
-    formatValue: (transaction: Transaction & { project: Project }) =>
+    formatValue: (transaction: Transaction & { project?: Project }) =>
       transaction.projectCode ? (
         <Badge className="whitespace-nowrap" style={{ backgroundColor: transaction.project?.color }}>
           {transaction.project?.name || ""}
@@ -63,7 +65,7 @@ export const standardFieldRenderers: Record<string, FieldRenderer> = {
     name: "Category",
     code: "categoryCode",
     sortable: true,
-    formatValue: (transaction: Transaction & { category: Category }) =>
+    formatValue: (transaction: Transaction & { category?: Category }) =>
       transaction.categoryCode ? (
         <Badge className="whitespace-nowrap" style={{ backgroundColor: transaction.category?.color }}>
           {transaction.category?.name || ""}

--- a/components/unsorted/analyze-form.tsx
+++ b/components/unsorted/analyze-form.tsx
@@ -90,7 +90,7 @@ export default function AnalyzeForm({
     const cachedResults = file.cachedParseResult
       ? Object.fromEntries(
           Object.entries(file.cachedParseResult as Record<string, string>).filter(
-            ([_, value]) => value !== null && value !== undefined && value !== ""
+            ([, value]) => value !== null && value !== undefined && value !== ""
           )
         )
       : {}
@@ -175,7 +175,7 @@ export default function AnalyzeForm({
       } else {
         const nonEmptyFields = Object.fromEntries(
           Object.entries(results.data?.output || {}).filter(
-            ([_, value]) => value !== null && value !== undefined && value !== ""
+            ([, value]) => value !== null && value !== undefined && value !== ""
           )
         )
         setFormData({ ...formData, ...nonEmptyFields })

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -11,6 +11,18 @@ const compat = new FlatCompat({
 
 const eslintConfig = [
   ...compat.extends("next/core-web-vitals", "next/typescript"),
+  {
+    rules: {
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        {
+          argsIgnorePattern: "^_",
+          varsIgnorePattern: "^_",
+          caughtErrorsIgnorePattern: "^_",
+        },
+      ],
+    },
+  },
 ];
 
 export default eslintConfig;

--- a/lib/email-sync/filters.test.ts
+++ b/lib/email-sync/filters.test.ts
@@ -23,7 +23,7 @@ describe("buildSearchCriteria", () => {
     expect(buildSearchCriteria({ initialSince: "2026-06-01", lastProcessedUid: 42 })).toEqual([["UID", "43:*"]])
   })
   it("defaults to ALL (entire mailbox) when initialSince is unset or invalid", () => {
-    expect(buildSearchCriteria({})).toEqual(["ALL"])
-    expect(buildSearchCriteria({ initialSince: "not-a-date" })).toEqual(["ALL"])
+    expect(buildSearchCriteria({})).toEqual([["ALL"]])
+    expect(buildSearchCriteria({ initialSince: "not-a-date" })).toEqual([["ALL"]])
   })
 })

--- a/lib/email-sync/filters.ts
+++ b/lib/email-sync/filters.ts
@@ -1,3 +1,5 @@
+import { ImapSearchCriteria } from "./types"
+
 export function attachmentMatchesExtensions(filename: string, allowedExtensions: string[]): boolean {
   if (!filename) return false
   const lower = filename.toLowerCase()
@@ -7,7 +9,7 @@ export function attachmentMatchesExtensions(filename: string, allowedExtensions:
   })
 }
 
-export function buildSearchCriteria(server: { initialSince?: string; lastProcessedUid?: number }): any[] {
+export function buildSearchCriteria(server: { initialSince?: string; lastProcessedUid?: number }): ImapSearchCriteria[] {
   // Once we have a watermark, only fetch newer messages by UID.
   if (server.lastProcessedUid && server.lastProcessedUid > 0) {
     return [["UID", `${server.lastProcessedUid + 1}:*`]]
@@ -20,5 +22,5 @@ export function buildSearchCriteria(server: { initialSince?: string; lastProcess
     }
   }
   // Default: no window set → scan the entire mailbox.
-  return ["ALL"]
+  return [["ALL"]]
 }

--- a/lib/email-sync/imap-client.ts
+++ b/lib/email-sync/imap-client.ts
@@ -1,6 +1,6 @@
 import imaps from "imap-simple"
 import { simpleParser } from "mailparser"
-import { ImapClient, ImapConnectConfig, ImapMessage } from "./types"
+import { ImapClient, ImapConnectConfig, ImapMessage, ImapSearchCriteria } from "./types"
 
 function buildImapConfig(config: ImapConnectConfig) {
   return {
@@ -18,7 +18,7 @@ function buildImapConfig(config: ImapConnectConfig) {
 }
 
 export const realImapClient: ImapClient = {
-  async fetchMessages(config: ImapConnectConfig, criteria: any[]): Promise<ImapMessage[]> {
+  async fetchMessages(config: ImapConnectConfig, criteria: ImapSearchCriteria[]): Promise<ImapMessage[]> {
     const connection = await imaps.connect(buildImapConfig(config))
 
     try {
@@ -29,7 +29,7 @@ export const realImapClient: ImapClient = {
       const messages: ImapMessage[] = []
       for (const item of results) {
         const uid = item.attributes.uid as number
-        const rawPart = item.parts.find((p: any) => p.which === "")
+        const rawPart = item.parts.find((p: { which: string }) => p.which === "")
         if (!rawPart) continue
         const parsed = await simpleParser(rawPart.body as string)
         messages.push({

--- a/lib/email-sync/ingest.test.ts
+++ b/lib/email-sync/ingest.test.ts
@@ -6,7 +6,7 @@ vi.mock("@/lib/db", () => {
   // applyResult now locks + re-reads inside a transaction; provide a tx with $queryRaw + update.
   const tx = { $queryRaw: vi.fn(async () => [{ data: { servers: [] } }]), appData: { update: vi.fn() } }
   return {
-    prisma: { appData: { findMany: vi.fn() }, $transaction: vi.fn(async (fn: any) => fn(tx)) },
+    prisma: { appData: { findMany: vi.fn() }, $transaction: vi.fn(async (fn: (tx: unknown) => unknown) => fn(tx)) },
   }
 })
 vi.mock("@/lib/files", () => ({ getDirectorySize: vi.fn(), getUserUploadsDirectory: vi.fn(() => "dir") }))
@@ -18,15 +18,16 @@ import { prisma } from "@/lib/db"
 import { realImapClient } from "@/lib/email-sync/imap-client"
 import { getDirectorySize } from "@/lib/files"
 import { ingestUnsortedFile } from "@/lib/uploads"
-import { ImapClient, ImapMessage } from "./types"
+import { File, User } from "@/prisma/client"
+import { EmailServer, ImapClient, ImapMessage } from "./types"
 
 beforeAll(() => {
   process.env.BETTER_AUTH_SECRET = "test-secret-key-for-encryption-unit-tests"
 })
 
-const user = { id: "user-1", email: "u@example.com", storageUsed: 0, storageLimit: -1 } as any
+const user = { id: "user-1", email: "u@example.com", storageUsed: 0, storageLimit: -1 } as unknown as User
 
-function makeServer(overrides: any = {}) {
+function makeServer(overrides: Partial<EmailServer> = {}): EmailServer {
   return {
     id: "srv-1", name: "Inbox", provider: "custom", host: "imap.example.com", port: 993,
     username: "u@example.com", password: "plaintext-pw", useSSL: true, isActive: true,
@@ -41,7 +42,7 @@ function fakeClient(messages: ImapMessage[]): ImapClient {
 
 describe("syncServer", () => {
   it("ingests matching attachments and advances the UID watermark", async () => {
-    const ingested: any[] = []
+    const ingested: { filename: string }[] = []
     const messages: ImapMessage[] = [
       {
         uid: 10, messageId: "<a@x>", subject: "Invoice", from: "biz@x.com", date: new Date(),
@@ -55,7 +56,7 @@ describe("syncServer", () => {
 
     const result = await syncServer(makeServer(), user, {
       client: fakeClient(messages),
-      ingest: async (_u, input) => { ingested.push(input); return { id: "f", ...input } as any },
+      ingest: async (_u, input) => { ingested.push(input); return { id: "f", ...input } as unknown as File },
     })
 
     expect(ingested.map((i) => i.filename)).toEqual(["invoice.pdf", "receipt.pdf"])
@@ -66,7 +67,7 @@ describe("syncServer", () => {
 
   it("does not advance the watermark when there are no new messages", async () => {
     const result = await syncServer(makeServer({ lastProcessedUid: 5 }), user, {
-      client: fakeClient([]), ingest: async () => ({}) as any,
+      client: fakeClient([]), ingest: async () => ({}) as unknown as File,
     })
     expect(result.processed).toBe(0)
     expect(result.lastProcessedUid).toBe(5)
@@ -74,14 +75,14 @@ describe("syncServer", () => {
   })
 
   it("skips messages at or below the watermark (defends against the IMAP `UID n:*` re-fetch quirk)", async () => {
-    const ingested: any[] = []
+    const ingested: { filename: string }[] = []
     // Some servers (Gmail/Dovecot) return the highest existing UID for `UID (last+1):*`
     // when there is no newer mail — re-delivering the watermark message.
     const result = await syncServer(makeServer({ lastProcessedUid: 603 }), user, {
       client: fakeClient([
         { uid: 603, attachments: [{ filename: "dup.pdf", contentType: "application/pdf", content: Buffer.from("x"), size: 1 }] },
       ]),
-      ingest: async (_u, input) => { ingested.push(input); return { id: "f" } as any },
+      ingest: async (_u, input) => { ingested.push(input); return { id: "f" } as unknown as File },
     })
     expect(ingested).toHaveLength(0)
     expect(result.processed).toBe(0)
@@ -91,7 +92,7 @@ describe("syncServer", () => {
   it("returns a friendly error when the stored password cannot be decrypted", async () => {
     const result = await syncServer(makeServer({ password: "v1:bad:bad:bad", lastProcessedUid: 9 }), user, {
       client: fakeClient([]),
-      ingest: async () => ({}) as any,
+      ingest: async () => ({}) as unknown as File,
     })
     expect(result.status).toBe("error")
     expect(result.errorMessage).toMatch(/could not be decrypted/i)
@@ -101,7 +102,7 @@ describe("syncServer", () => {
   it("reports error status and keeps the old watermark on client failure", async () => {
     const result = await syncServer(makeServer({ lastProcessedUid: 7 }), user, {
       client: { fetchMessages: vi.fn(async () => { throw new Error("auth failed") }) },
-      ingest: async () => ({}) as any,
+      ingest: async () => ({}) as unknown as File,
     })
     expect(result.status).toBe("error")
     expect(result.errorMessage).toContain("auth failed")
@@ -114,7 +115,7 @@ describe("runEmailSync storage recompute guard", () => {
     vi.clearAllMocks()
     vi.mocked(prisma.appData.findMany).mockResolvedValue([
       { userId: "u1", user, data: { servers: [makeServer()] } },
-    ] as any)
+    ] as unknown as File)
   })
 
   it("skips getDirectorySize when nothing was ingested (regression: ENOENT on missing uploads dir)", async () => {
@@ -127,7 +128,7 @@ describe("runEmailSync storage recompute guard", () => {
     vi.mocked(realImapClient.fetchMessages).mockResolvedValue([
       { uid: 20, attachments: [{ filename: "a.pdf", contentType: "application/pdf", content: Buffer.from("x"), size: 1 }] },
     ])
-    vi.mocked(ingestUnsortedFile).mockResolvedValue({ id: "f" } as any)
+    vi.mocked(ingestUnsortedFile).mockResolvedValue({ id: "f" } as unknown as File)
     vi.mocked(getDirectorySize).mockResolvedValue(123)
     await runEmailSync()
     expect(getDirectorySize).toHaveBeenCalledTimes(1)
@@ -136,7 +137,7 @@ describe("runEmailSync storage recompute guard", () => {
   it("cron run (respectInterval) skips a server still within its syncInterval", async () => {
     vi.mocked(prisma.appData.findMany).mockResolvedValue([
       { userId: "u1", user, data: { servers: [makeServer({ lastSyncedAt: new Date().toISOString(), syncInterval: 6 })] } },
-    ] as any)
+    ] as unknown as File)
     const results = await runEmailSync({ respectInterval: true })
     expect(realImapClient.fetchMessages).not.toHaveBeenCalled()
     expect(results).toHaveLength(0)
@@ -149,7 +150,7 @@ describe("runEmailSync storage recompute guard", () => {
         user,
         data: { servers: [makeServer({ lastSyncedAt: new Date(Date.now() - 90 * 60_000).toISOString(), syncInterval: 60 })] },
       },
-    ] as any)
+    ] as unknown as File)
     vi.mocked(realImapClient.fetchMessages).mockResolvedValue([])
     await runEmailSync({ respectInterval: true })
     expect(realImapClient.fetchMessages).toHaveBeenCalledTimes(1)
@@ -158,7 +159,7 @@ describe("runEmailSync storage recompute guard", () => {
   it("manual sync (no respectInterval) bypasses the interval throttle", async () => {
     vi.mocked(prisma.appData.findMany).mockResolvedValue([
       { userId: "u1", user, data: { servers: [makeServer({ lastSyncedAt: new Date().toISOString(), syncInterval: 6 })] } },
-    ] as any)
+    ] as unknown as File)
     vi.mocked(realImapClient.fetchMessages).mockResolvedValue([])
     await runEmailSync({ userId: "u1" })
     expect(realImapClient.fetchMessages).toHaveBeenCalledTimes(1)

--- a/lib/email-sync/ingest.ts
+++ b/lib/email-sync/ingest.ts
@@ -1,3 +1,4 @@
+import { Prisma } from "@/prisma/client"
 import { prisma } from "@/lib/db"
 import { decryptSecret } from "@/lib/encryption"
 import { ingestUnsortedFile } from "@/lib/uploads"
@@ -6,7 +7,7 @@ import { updateUser } from "@/models/users"
 import { File, User } from "@/prisma/client"
 import { attachmentMatchesExtensions, buildSearchCriteria } from "./filters"
 import { realImapClient } from "./imap-client"
-import { ImapClient, SyncResult } from "./types"
+import { EmailServer, ImapClient, SyncResult } from "./types"
 
 type SyncDeps = {
   client?: ImapClient
@@ -16,7 +17,7 @@ type SyncDeps = {
   ) => Promise<File>
 }
 
-export async function syncServer(server: any, user: User, deps: SyncDeps = {}): Promise<SyncResult> {
+export async function syncServer(server: EmailServer, user: User, deps: SyncDeps = {}): Promise<SyncResult> {
   const client = deps.client ?? realImapClient
   const ingest = deps.ingest ?? ingestUnsortedFile
 
@@ -91,13 +92,13 @@ async function applyResult(userId: string, result: SyncResult) {
   // (the hourly cron container vs. a manual "Sync Now" in the web app) can't clobber the
   // other's watermark/status with a stale read-modify-write.
   await prisma.$transaction(async (tx) => {
-    const locked = await tx.$queryRaw<{ data: any }[]>`
+    const locked = await tx.$queryRaw<{ data: Record<string, unknown> }[]>`
       SELECT data FROM app_data WHERE user_id = ${userId}::uuid AND app = 'email' FOR UPDATE
     `
     if (!locked.length) return
-    const data = locked[0].data as any
+    const data = locked[0].data as Record<string, unknown>
     const now = new Date().toISOString()
-    data.servers = (data.servers || []).map((s: any) =>
+    data.servers = ((data.servers as EmailServer[]) || []).map((s) =>
       s.id === result.serverId
         ? {
             ...s,
@@ -108,13 +109,13 @@ async function applyResult(userId: string, result: SyncResult) {
           }
         : s
     )
-    await tx.appData.update({ where: { userId_app: { userId, app: "email" } }, data: { data } })
+    await tx.appData.update({ where: { userId_app: { userId, app: "email" } }, data: { data: data as Prisma.InputJsonValue } })
   })
 }
 
 // Per-server throttle: when the cron runs, skip a server whose last sync is more recent
 // than its configured interval. Manual "Sync Now" passes respectInterval=false to bypass.
-function isThrottled(server: any): boolean {
+function isThrottled(server: EmailServer): boolean {
   if (!server.lastSyncedAt) return false
   const intervalMinutes = server.syncInterval ?? 60
   const elapsedMinutes = (Date.now() - new Date(server.lastSyncedAt).getTime()) / 60_000
@@ -131,9 +132,9 @@ export async function runEmailSync(
 
   const results: SyncResult[] = []
   for (const row of rows) {
-    const data = row.data as any
-    const servers: any[] = (data?.servers || []).filter(
-      (s: any) => s.isActive && (!scope.serverId || s.id === scope.serverId)
+    const data = row.data as Record<string, unknown>
+    const servers: EmailServer[] = ((data?.servers as EmailServer[]) || []).filter(
+      (s) => s.isActive && (!scope.serverId || s.id === scope.serverId)
     )
     for (const server of servers) {
       if (scope.respectInterval && isThrottled(server)) continue

--- a/lib/email-sync/types.ts
+++ b/lib/email-sync/types.ts
@@ -22,8 +22,25 @@ export type ImapConnectConfig = {
   tls: boolean
 }
 
+export type ImapSearchCriteria = Array<string | string[] | Date>
+
+export type EmailServer = {
+  id: string
+  username: string
+  password: string
+  host: string
+  port: number
+  useSSL: boolean
+  isActive: boolean
+  lastProcessedUid?: number
+  allowedExtensions: string[]
+  lastSyncedAt?: string
+  syncInterval?: number
+  status: string
+}
+
 export type ImapClient = {
-  fetchMessages: (config: ImapConnectConfig, criteria: any[]) => Promise<ImapMessage[]>
+  fetchMessages: (config: ImapConnectConfig, criteria: ImapSearchCriteria[]) => Promise<ImapMessage[]>
 }
 
 export type SyncResult = {

--- a/lib/stats.ts
+++ b/lib/stats.ts
@@ -53,7 +53,7 @@ export const incompleteTransactionFields = (fields: Field[], transaction: Transa
 
   return requiredFields.filter((field) => {
     const value = field.isExtra
-      ? (transaction.extra as Record<string, any>)?.[field.code]
+      ? (transaction.extra as Record<string, unknown>)?.[field.code]
       : transaction[field.code as keyof Transaction]
 
     return value === undefined || value === null || value === ""

--- a/lib/uploads.test.ts
+++ b/lib/uploads.test.ts
@@ -7,7 +7,7 @@ const tmpRoot = await mkdtemp(path.join(tmpdir(), "th-uploads-"))
 process.env.UPLOAD_PATH = tmpRoot
 process.env.SELF_HOSTED_MODE = "true"
 
-const created: any[] = []
+const created: Record<string, unknown>[] = []
 vi.mock("./config", () => ({
   default: {
     upload: { images: { maxWidth: 1920, maxHeight: 1080, quality: 80 } },
@@ -15,7 +15,7 @@ vi.mock("./config", () => ({
   },
 }))
 vi.mock("@/models/files", () => ({
-  createFile: vi.fn(async (userId: string, data: any) => {
+  createFile: vi.fn(async (userId: string, data: Record<string, unknown>) => {
     const row = { ...data, userId }
     created.push(row)
     return row
@@ -24,7 +24,7 @@ vi.mock("@/models/files", () => ({
 
 const { ingestUnsortedFile } = await import("./uploads")
 
-const user = { id: "user-1", email: "u@example.com", storageUsed: 0, storageLimit: -1 } as any
+const user = { id: "user-1", email: "u@example.com", storageUsed: 0, storageLimit: -1 } as Record<string, unknown>
 
 afterAll(async () => {
   await rm(tmpRoot, { recursive: true, force: true })
@@ -43,7 +43,7 @@ describe("ingestUnsortedFile", () => {
     expect(file.filename).toBe("invoice.pdf")
     expect(file.mimetype).toBe("application/pdf")
     expect(file.path).toMatch(/^unsorted\/.+\.pdf$/)
-    expect((file.metadata as any).source).toBe("email")
+    expect((file.metadata as Record<string, unknown>).source).toBe("email")
 
     const onDisk = await readFile(path.join(tmpRoot, user.email, file.path))
     expect(onDisk.equals(buffer)).toBe(true)

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -18,7 +18,7 @@ export function formatCurrency(total: number, currency: string) {
       maximumFractionDigits: 2,
       useGrouping: true,
     }).format(total / 100)
-  } catch (error) {
+  } catch {
     // can happen with custom currencies and crypto
     return `${currency} ${total / 100}`
   }
@@ -108,7 +108,7 @@ export function generateUUID(): string {
   if (typeof crypto !== "undefined" && crypto.randomUUID) {
     try {
       return crypto.randomUUID()
-    } catch (error) {
+    } catch {
       // Fall through to next method
     }
   }
@@ -126,7 +126,7 @@ export function generateUUID(): string {
       // Convert to UUID string format
       const hex = Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("")
       return [hex.slice(0, 8), hex.slice(8, 12), hex.slice(12, 16), hex.slice(16, 20), hex.slice(20, 32)].join("-")
-    } catch (error) {
+    } catch {
       // Fall through to Math.random() fallback
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "@sentry/nextjs": "^9.11.0",
         "@types/imap": "^0.8.43",
         "@types/mailparser": "^3.4.6",
-        "@types/mime-types": "^2.1.4",
+        "@types/mime-types": "^3.0.1",
         "@types/sharp": "^0.31.1",
         "better-auth": "^1.2.10",
         "class-variance-authority": "^0.7.1",
@@ -63,7 +63,7 @@
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
-        "@types/node": "^20",
+        "@types/node": "^26",
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "eslint": "^9",
@@ -71,7 +71,7 @@
         "postcss": "^8",
         "prisma": "^6.6.0",
         "tailwindcss": "^3.4.1",
-        "typescript": "^5",
+        "typescript": "^6",
         "vitest": "^4.1.8"
       }
     },
@@ -482,7 +482,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -499,7 +498,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -516,7 +514,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -533,7 +530,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -550,7 +546,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -567,7 +562,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -584,7 +578,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -601,7 +594,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -618,7 +610,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -635,7 +626,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -652,7 +642,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -669,7 +658,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -686,7 +674,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -703,7 +690,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -720,7 +706,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -737,7 +722,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -754,7 +738,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -771,7 +754,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -788,7 +770,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -805,7 +786,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -822,7 +802,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -839,7 +818,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -856,7 +834,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -873,7 +850,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -890,7 +866,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -907,7 +882,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -918,9 +892,9 @@
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.5.1.tgz",
-      "integrity": "sha512-soEIOALTfTK6EjmKMMoLugwaP0rzkad90iIWd1hMO9ARkSAyjfMfkRRhLvD5qH7vvM0Cg72pieUfR6yh6XxC4w==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -950,9 +924,9 @@
       }
     },
     "node_modules/@eslint-community/regexpp": {
-      "version": "4.12.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
-      "integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5191,9 +5165,9 @@
       }
     },
     "node_modules/@types/mime-types": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@types/mime-types/-/mime-types-2.1.4.tgz",
-      "integrity": "sha512-lfU4b34HOri+kAY5UheuFMWPDOI+OPceBSHZKp69gEyTL/mmJ4cnU6Y/rlme3UL3GyOn6Y42hyIEw0/q8sWx5w==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/mime-types/-/mime-types-3.0.1.tgz",
+      "integrity": "sha512-xRMsfuQbnRq1Ef+C+RKaENOxXX87Ygl38W1vDfPHRku02TgQr+Qd8iivLtAMcR0KF5/29xlnFihkTlbqFrGOVQ==",
       "license": "MIT"
     },
     "node_modules/@types/mysql": {
@@ -5206,12 +5180,12 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.17.25",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.25.tgz",
-      "integrity": "sha512-bT+r2haIlplJUYtlZrEanFHdPIZTeiMeh/fSOEbOOfWf9uTn+lg8g0KU6Q3iMgjd9FLuuMAgfCNSkjUbxL6E3Q==",
+      "version": "26.0.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.0.1.tgz",
+      "integrity": "sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.19.2"
+        "undici-types": "~8.3.0"
       }
     },
     "node_modules/@types/pg": {
@@ -5291,21 +5265,20 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.27.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.27.0.tgz",
-      "integrity": "sha512-4henw4zkePi5p252c8ncBLzLce52SEUz2Ebj8faDnuUXz2UuHEONYcJ+G0oaCF+bYCWVZtrGzq3FD7YXetmnSA==",
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.62.0.tgz",
+      "integrity": "sha512-o+mpz7EYiMzXoySXiKmzlabIvTVqUuK5yLrAedRPRDA0IpPFMUV1IXt6OqljIxX/kumN6EjUYp41Hqelh6p/Dw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.27.0",
-        "@typescript-eslint/type-utils": "8.27.0",
-        "@typescript-eslint/utils": "8.27.0",
-        "@typescript-eslint/visitor-keys": "8.27.0",
-        "graphemer": "^1.4.0",
-        "ignore": "^5.3.1",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.62.0",
+        "@typescript-eslint/type-utils": "8.62.0",
+        "@typescript-eslint/utils": "8.62.0",
+        "@typescript-eslint/visitor-keys": "8.62.0",
+        "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
-        "ts-api-utils": "^2.0.1"
+        "ts-api-utils": "^2.5.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -5315,23 +5288,33 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.0.0 || ^8.0.0-alpha.0",
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <5.9.0"
+        "@typescript-eslint/parser": "^8.62.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.27.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.27.0.tgz",
-      "integrity": "sha512-XGwIabPallYipmcOk45DpsBSgLC64A0yvdAkrwEzwZ2viqGqRUJ8eEYoPz0CWnutgAFbNMPdsGGvzjSmcWVlEA==",
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.62.0.tgz",
+      "integrity": "sha512-dzHeT2gySzZtLDsuqxU9AkYgIsQoHAHtRBpOqM+Ofzx1Bwrd2RcCjQJ+6iQbsHOIR6NS33bF2W1k3blN1zLDrA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.27.0",
-        "@typescript-eslint/types": "8.27.0",
-        "@typescript-eslint/typescript-estree": "8.27.0",
-        "@typescript-eslint/visitor-keys": "8.27.0",
-        "debug": "^4.3.4"
+        "@typescript-eslint/scope-manager": "8.62.0",
+        "@typescript-eslint/types": "8.62.0",
+        "@typescript-eslint/typescript-estree": "8.62.0",
+        "@typescript-eslint/visitor-keys": "8.62.0",
+        "debug": "^4.4.3"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -5341,19 +5324,41 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <5.9.0"
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.62.0.tgz",
+      "integrity": "sha512-wexnCqiTg7BOGtbLDftYpRWlmLq4xfoMd7BKFR6Y75sZS3QmRKLdN3yWLhmIYgqMmP/OXWpj3H8odkb5nGURCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.62.0",
+        "@typescript-eslint/types": "^8.62.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.27.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.27.0.tgz",
-      "integrity": "sha512-8oI9GwPMQmBryaaxG1tOZdxXVeMDte6NyJA4i7/TWa4fBwgnAXYlIQP+uYOeqAaLJ2JRxlG9CAyL+C+YE9Xknw==",
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.62.0.tgz",
+      "integrity": "sha512-1lX38kNxXIRb8mEc3lbq5mdHq1Pf2+U0nFU65KfT18mtPxxl0fvjuEE92mHuXPuCtElJhOrddOpyMlM3Z0umEA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.27.0",
-        "@typescript-eslint/visitor-keys": "8.27.0"
+        "@typescript-eslint/types": "8.62.0",
+        "@typescript-eslint/visitor-keys": "8.62.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -5363,17 +5368,35 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.62.0.tgz",
+      "integrity": "sha512-y2GAdB6ykaXUvuspbYnizQc4oDDz0Tz/Yc7iWrXf9mx8vm/L/0vLHCe0tS2boG96Zy+DivnVDQ9ZUEWoHqqx1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.27.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.27.0.tgz",
-      "integrity": "sha512-wVArTVcz1oJOIEJxui/nRhV0TXzD/zMSOYi/ggCfNq78EIszddXcJb7r4RCp/oBrjt8n9A0BSxRMKxHftpDxDA==",
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.62.0.tgz",
+      "integrity": "sha512-+g5O3j0w2ldzC86Pv6fvbO/xhAonbJFIdf/MKQ1d30gndlsVzUOE83ldfSE15Qrl9fhFjK6AovHs5Wpp6vx86w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "8.27.0",
-        "@typescript-eslint/utils": "8.27.0",
-        "debug": "^4.3.4",
-        "ts-api-utils": "^2.0.1"
+        "@typescript-eslint/types": "8.62.0",
+        "@typescript-eslint/typescript-estree": "8.62.0",
+        "@typescript-eslint/utils": "8.62.0",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -5383,14 +5406,14 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <5.9.0"
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.27.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.27.0.tgz",
-      "integrity": "sha512-/6cp9yL72yUHAYq9g6DsAU+vVfvQmd1a8KyA81uvfDE21O2DwQ/qxlM4AR8TSdAu+kJLBDrEHKC5/W2/nxsY0A==",
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.62.0.tgz",
+      "integrity": "sha512-KvAclkktORPvM54TgLgA4z9HIV1M8zOgw9ZVNXl9f/8dLYfXYX1wkMXP7qmabpijQRV5bHJLOmoyGQbLMaUYeg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5402,20 +5425,21 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.27.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.27.0.tgz",
-      "integrity": "sha512-BnKq8cqPVoMw71O38a1tEb6iebEgGA80icSxW7g+kndx0o6ot6696HjG7NdgfuAVmVEtwXUr3L8R9ZuVjoQL6A==",
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.62.0.tgz",
+      "integrity": "sha512-+hVbNxtW64pIcZWDPGbyaKF7vp2IBTVY5ma1blwwksrjdsbdqqEKvJWMGbBofei4F6Dovx1M0RJgoFeNu2279A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.27.0",
-        "@typescript-eslint/visitor-keys": "8.27.0",
-        "debug": "^4.3.4",
-        "fast-glob": "^3.3.2",
-        "is-glob": "^4.0.3",
-        "minimatch": "^9.0.4",
-        "semver": "^7.6.0",
-        "ts-api-utils": "^2.0.1"
+        "@typescript-eslint/project-service": "8.62.0",
+        "@typescript-eslint/tsconfig-utils": "8.62.0",
+        "@typescript-eslint/types": "8.62.0",
+        "@typescript-eslint/visitor-keys": "8.62.0",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -5425,76 +5449,59 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <5.9.0"
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/fast-glob": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
-      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.stat": "^2.0.2",
-        "@nodelib/fs.walk": "^1.2.3",
-        "glob-parent": "^5.1.2",
-        "merge2": "^1.3.0",
-        "micromatch": "^4.0.8"
+        "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": ">=8.6.0"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "is-glob": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.27.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.27.0.tgz",
-      "integrity": "sha512-njkodcwH1yvmo31YWgRHNb/x1Xhhq4/m81PhtvmRngD8iHPehxffz1SNCO+kwaePhATC+kOa/ggmvPoPza5i0Q==",
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.62.0.tgz",
+      "integrity": "sha512-82r66fi9zYwZ+mTq3vKgwjbZ1PVk/DJzrXFLpG6RnBbdvH8TEGVHIs9H4d2drhkOzf0syZuD/OZvvlu6GDbP4g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-community/eslint-utils": "^4.4.0",
-        "@typescript-eslint/scope-manager": "8.27.0",
-        "@typescript-eslint/types": "8.27.0",
-        "@typescript-eslint/typescript-estree": "8.27.0"
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.62.0",
+        "@typescript-eslint/types": "8.62.0",
+        "@typescript-eslint/typescript-estree": "8.62.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -5504,19 +5511,19 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <5.9.0"
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.27.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.27.0.tgz",
-      "integrity": "sha512-WsXQwMkILJvffP6z4U3FYJPlbf/j07HIxmDjZpbNvBJkMfvwXj5ACRkkHwBDvLBbDbtX5TdU64/rcvKJ/vuInQ==",
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.62.0.tgz",
+      "integrity": "sha512-CY3uyFSRbcQv3nnSv8S0+lDftMVz6P963PoRlxrV7ew/Md564g9ut60PYzdLM5qW4jFn93GBF+Soi90ISAN+GQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.27.0",
-        "eslint-visitor-keys": "^4.2.0"
+        "@typescript-eslint/types": "8.62.0",
+        "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -5524,6 +5531,19 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/@unrs/rspack-resolver-binding-darwin-arm64": {
@@ -7114,9 +7134,9 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
-      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -8587,13 +8607,6 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "license": "ISC",
       "peer": true
-    },
-    "node_modules/graphemer": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
-      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/has-bigints": {
       "version": "1.1.0",
@@ -13514,9 +13527,9 @@
       "license": "MIT"
     },
     "node_modules/ts-api-utils": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
-      "integrity": "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -13652,9 +13665,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.8.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
-      "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
@@ -13691,9 +13704,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
       "license": "MIT"
     },
     "node_modules/unicode-properties": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@sentry/nextjs": "^9.11.0",
     "@types/imap": "^0.8.43",
     "@types/mailparser": "^3.4.6",
-    "@types/mime-types": "^2.1.4",
+    "@types/mime-types": "^3.0.1",
     "@types/sharp": "^0.31.1",
     "better-auth": "^1.2.10",
     "class-variance-authority": "^0.7.1",
@@ -68,7 +68,7 @@
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",
-    "@types/node": "^20",
+    "@types/node": "^26",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "eslint": "^9",
@@ -76,7 +76,7 @@
     "postcss": "^8",
     "prisma": "^6.6.0",
     "tailwindcss": "^3.4.1",
-    "typescript": "^5",
+    "typescript": "^6",
     "vitest": "^4.1.8"
   },
   "overrides": {

--- a/types/css.d.ts
+++ b/types/css.d.ts
@@ -1,0 +1,6 @@
+/**
+ * Ambient declaration for plain (non-module) CSS side-effect imports, e.g. `import "./globals.css"`.
+ * TypeScript 6 defaults `noUncheckedSideEffectImports` to true, and Next.js only ships
+ * declarations for `*.module.css`/`.sass`/`.scss`, not plain stylesheets.
+ */
+declare module "*.css" {}


### PR DESCRIPTION
Bumps `typescript` ^5→^6, `@types/node` ^20→^26, `@types/mime-types` ^2→^3.

TypeScript 6 requires two compatibility fixes, included here:
- Casts two `Uint8Array` values to `BlobPart`/`BodyInit` where TS 6 tightened DOM lib overload resolution.
- Adds `types/css.d.ts` (`declare module "*.css" {}`). TS 6 defaults `noUncheckedSideEffectImports` to `true`, and Next.js only ships type declarations for `*.module.css`, not plain stylesheets, which broke the two bare `import "./globals.css"` side-effect imports.

Stacked on #111 (`deps/node-24-lts`). Diff includes that PR's commit until it merges.