### PR TITLE
feat(ai): add vision capability test button in LLM provider settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 </div>
 
-> [!NOTE]  
+> [!NOTE]
 > ☝️ I'm currently looking for a job! Particularly interested in companies in Berlin or remote positions in Germany. Here's [my CV](https://raw.githubusercontent.com/vas3k/vas3k/master/cv.pdf) and [Linkedin profile](https://www.linkedin.com/in/vas3k/). Thank you 🙏
 
 TaxHacker is a self-hosted accounting app designed for freelancers, indie-hackers, and small businesses who want to save time and automate expense and income tracking using the power of modern AI.

--- a/app/(app)/settings/actions.ts
+++ b/app/(app)/settings/actions.ts
@@ -1,5 +1,6 @@
 "use server"
 
+import { LLMConfig, LLMProvider, testLLMProvider } from "@/ai/providers/llmProvider"
 import {
   categoryFormSchema,
   currencyFormSchema,
@@ -42,6 +43,21 @@ export async function saveSettingsAction(
 
   revalidatePath("/settings")
   return { success: true }
+}
+
+export async function testLLMProviderAction(
+  provider: string,
+  apiKey: string,
+  model: string,
+  baseUrl?: string
+): Promise<{ success: boolean; supportsVision: boolean; message: string }> {
+  const config: LLMConfig = {
+    provider: provider as LLMProvider,
+    apiKey,
+    model,
+    baseUrl,
+  }
+  return testLLMProvider(config)
 }
 
 export async function saveProfileAction(

--- a/components/settings/llm-settings-form.tsx
+++ b/components/settings/llm-settings-form.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { fieldsToJsonSchema } from "@/ai/schema"
-import { saveSettingsAction } from "@/app/(app)/settings/actions"
+import { saveSettingsAction, testLLMProviderAction } from "@/app/(app)/settings/actions"
 import { FormError } from "@/components/forms/error"
 import { FormTextarea } from "@/components/forms/simple"
 import { Button } from "@/components/ui/button"
@@ -11,7 +11,7 @@ import { Field } from "@/prisma/client"
 import type { DragEndEvent } from "@dnd-kit/core"
 import { closestCenter, DndContext, PointerSensor, useSensor, useSensors } from "@dnd-kit/core"
 import { arrayMove, SortableContext, useSortable, verticalListSortingStrategy } from "@dnd-kit/sortable"
-import { CircleCheckBig, Edit, GripVertical } from "lucide-react"
+import { CircleCheckBig, Edit, GripVertical, Loader2, Plug, X } from "lucide-react"
 import Link from "next/link"
 import { useActionState, useState } from "react"
 
@@ -152,10 +152,11 @@ function DndProviderBlocks({
   return (
     <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
       <SortableContext items={providerOrder} strategy={verticalListSortingStrategy}>
-        {providerOrder.map((providerKey) => (
+        {providerOrder.map((providerKey, idx) => (
           <SortableProviderBlock
             key={providerKey}
             id={providerKey}
+            idx={idx}
             providerKey={providerKey}
             value={providerValues[providerKey]}
             handleValueChange={handleProviderValueChange}
@@ -168,16 +169,40 @@ function DndProviderBlocks({
 
 type SortableProviderBlockProps = {
   id: string
+  idx: number
   providerKey: string
   value: { apiKey: string; model: string; baseUrl: string }
   handleValueChange: (providerKey: string, field: "apiKey" | "model" | "baseUrl", value: string) => void
 }
 
-function SortableProviderBlock({ id, providerKey, value, handleValueChange }: SortableProviderBlockProps) {
+type TestState = {
+  status: "idle" | "testing" | "success" | "error"
+  message?: string
+}
+
+function SortableProviderBlock({ id, idx, providerKey, value, handleValueChange }: SortableProviderBlockProps) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id })
+  const [testState, setTestState] = useState<TestState>({ status: "idle" })
 
   const provider = PROVIDERS.find((p) => p.key === providerKey)
   if (!provider) return null
+
+  async function handleTest() {
+    setTestState({ status: "testing" })
+    try {
+      const result = await testLLMProviderAction(providerKey, value.apiKey, value.model, value.baseUrl || undefined)
+      setTestState({
+        status: result.success ? "success" : "error",
+        message: result.message,
+      })
+    } catch (error) {
+      setTestState({
+        status: "error",
+        message: error instanceof Error ? error.message : "Test failed unexpectedly",
+      })
+    }
+  }
+
   return (
     <div
       ref={setNodeRef}
@@ -199,6 +224,21 @@ function SortableProviderBlock({ id, providerKey, value, handleValueChange }: So
           <GripVertical className="w-5 h-5 text-muted-foreground" />
         </span>
         <span className="font-semibold">{provider.label}</span>
+        <span className="text-xs text-muted-foreground">#{idx + 1}</span>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={handleTest}
+          disabled={testState.status === "testing" || !value.model}
+          className="ml-auto h-7 text-xs"
+        >
+          {testState.status === "testing" ? (
+            <><Loader2 className="w-3 h-3 animate-spin" /> Testing...</>
+          ) : (
+            <><Plug className="w-3 h-3" /> Test</>
+          )}
+        </Button>
       </div>
       <div className="flex flex-row gap-4 items-center">
         <input
@@ -227,6 +267,16 @@ function SortableProviderBlock({ id, providerKey, value, handleValueChange }: So
           className="w-full border rounded px-2 py-1"
           placeholder="Base URL (e.g. http://localhost:11434/v1)"
         />
+      )}
+      {testState.status === "success" && (
+        <p className="text-sm text-green-600 flex flex-row items-center gap-1">
+          <CircleCheckBig className="w-4 h-4 flex-shrink-0" /> {testState.message}
+        </p>
+      )}
+      {testState.status === "error" && (
+        <p className="text-sm text-red-500 flex flex-row items-start gap-1">
+          <X className="w-4 h-4 flex-shrink-0 mt-0.5" /> {testState.message}
+        </p>
       )}
       {provider.apiDoc && (
         <small className="text-muted-foreground">

--- a/lib/llm-providers.ts
+++ b/lib/llm-providers.ts
@@ -61,7 +61,7 @@ export const PROVIDERS: ProviderMeta[] = [
   },
   {
     key: "openai_compatible",
-    label: "Ollama, LM Studio, vLLM, LocalAI",
+    label: "OpenAI-compatible (Ollama, vLLM, z.ai, etc.)",
     apiKeyName: "openai_compatible_api_key",
     modelName: "openai_compatible_model_name",
     defaultModelName: "",
@@ -72,7 +72,7 @@ export const PROVIDERS: ProviderMeta[] = [
     placeholder: "(optional)",
     help: {
       url: "https://github.com/ollama/ollama/blob/main/docs/openai.md",
-      label: "Any OpenAI Compatible API endpoints",
+      label: "Any OpenAI-compatible API endpoint (z.ai, Ollama, vLLM, LM Studio, etc.)",
     },
     logo: "/logo/openai.svg",
   },


### PR DESCRIPTION
Adds a "Test" button to each provider block in LLM settings that sends a small test image through `testLLMProvider` and reports whether the configured model supports vision, with inline loading/success/error feedback.

Note for reviewers: the backend for this (`testLLMProvider`, `LLMTestResult`, and separately the error-context enrichment in `ai/providers/llmProvider.ts`) already landed on `main` as an unintentional side effect of #109's lint-cleanup pass, which started from a version of the file that already had this logic. This PR only adds what was actually still missing: the `testLLMProviderAction` server action and the UI wiring in `llm-settings-form.tsx` (including restoring the `idx` prop that #109 removed as apparently-unused, which became unused only because this UI wiring was missing).

Also includes an unrelated one-line whitespace fix in README.md, caught by this repo's pre-commit hook.