### PR TITLE
ci: make branch-image publish manual instead of automatic on every PR

### DIFF
--- a/.github/workflows/docker-branch.yml
+++ b/.github/workflows/docker-branch.yml
@@ -1,26 +1,41 @@
 name: Build and Publish Branch Docker Image
 
 on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "Pull request number to build and publish"
+        required: true
+        type: string
   pull_request:
-    types: [opened, synchronize, reopened, closed]
+    types: [closed]
     branches: [main]
 
 concurrency:
-  group: docker-branch-pr-${{ github.event.pull_request.number }}
-  cancel-in-progress: ${{ github.event.action != 'closed' }}
+  group: docker-branch-pr-${{ github.event.inputs.pr_number || github.event.pull_request.number }}
+  cancel-in-progress: ${{ github.event_name == 'workflow_dispatch' }}
 
 jobs:
   build:
-    if: github.event.action != 'closed'
+    if: github.event_name == 'workflow_dispatch'
     name: Build and Push (amd64)
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
     steps:
+      - name: Validate PR number
+        run: |
+          set -euo pipefail
+          if ! [[ "${{ inputs.pr_number }}" =~ ^[0-9]+$ ]]; then
+            echo "::error::pr_number must be a positive integer, got: ${{ inputs.pr_number }}"
+            exit 1
+          fi
+
       - name: Checkout repository
         uses: actions/checkout@v7
         with:
+          ref: refs/pull/${{ inputs.pr_number }}/head
           persist-credentials: false
 
       - name: Set up Node.js
@@ -48,7 +63,7 @@ jobs:
         with:
           images: ghcr.io/${{ github.repository_owner }}/taxhacker
           tags: |
-            type=ref,event=pr
+            type=raw,value=pr-${{ inputs.pr_number }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v7.2.0
@@ -64,7 +79,7 @@ jobs:
           cache-to: type=gha,mode=max
 
   cleanup:
-    if: github.event.action == 'closed'
+    if: github.event_name == 'pull_request' && github.event.action == 'closed'
     name: Delete Branch Image
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
The "Build and Push (amd64)" job in `docker-branch.yml` fails on essentially every PR from a fork: GitHub restricts `GITHUB_TOKEN` to read-only for `pull_request`-triggered workflows originating from a fork, so the final push to `ghcr.io` is always denied ("installation not allowed to Write organization package") after a successful build. This isn't something a fork's PR can fix — it's GitHub's built-in fork-security boundary, not a bug in the workflow's build logic.

Switches the build job's trigger from `pull_request` to `workflow_dispatch` (manual, taking a `pr_number` input — validated as a plain integer before use in the checkout `ref`), so it no longer runs automatically and fails on every external PR. A maintainer or collaborator can still run it by hand from the Actions tab when they want a PR-tagged image published. The cleanup job (deleting a PR's image from GHCR on close) stays automatic on `pull_request: closed`, since it's idempotent and doesn't build or publish untrusted code.

If publishing images automatically from trusted (same-repo, non-fork, non-Dependabot) branches is still wanted, that would need a separate `push`-triggered workflow scoped to this repo's own branches — happy to open that as a follow-up if useful.