### PR TITLE
Fixed transaction dates displaying one day earlier in timezones behind UTC.

### DIFF
--- a/components/transactions/edit.tsx
+++ b/components/transactions/edit.tsx
@@ -48,7 +48,7 @@ export default function TransactionEditForm({
     type: transaction.type || "expense",
     categoryCode: transaction.categoryCode || settings.default_category,
     projectCode: transaction.projectCode || settings.default_project,
-    issuedAt: transaction.issuedAt ? format(transaction.issuedAt, "yyyy-MM-dd") : "",
+    issuedAt: transaction.issuedAt ? transaction.issuedAt.toISOString().slice(0, 10) : "",
     note: transaction.note || "",
     items: transaction.items || [],
     ...extraFields.reduce(

--- a/components/transactions/list.tsx
+++ b/components/transactions/list.tsx
@@ -7,7 +7,6 @@ import { Table, TableBody, TableCell, TableFooter, TableHead, TableHeader, Table
 import { calcNetTotalPerCurrency, calcTotalPerCurrency, isTransactionIncomplete } from "@/lib/stats"
 import { cn, formatCurrency } from "@/lib/utils"
 import { Category, Field, Project, Transaction } from "@/prisma/client"
-import { formatDate } from "date-fns"
 import { ArrowDownIcon, ArrowUpIcon, File } from "lucide-react"
 import { useRouter, useSearchParams } from "next/navigation"
 import { useEffect, useMemo, useState } from "react"
@@ -46,7 +45,7 @@ export const standardFieldRenderers: Record<string, FieldRenderer> = {
     classes: "min-w-[100px]",
     sortable: true,
     formatValue: (transaction: Transaction) =>
-      transaction.issuedAt ? formatDate(transaction.issuedAt, "yyyy-MM-dd") : "",
+      transaction.issuedAt ? transaction.issuedAt.toISOString().slice(0, 10) : "",
   },
   projectCode: {
     name: "Project",

--- a/forms/transactions.ts
+++ b/forms/transactions.ts
@@ -43,9 +43,11 @@ export const transactionFormSchema = z
             message: "Invalid date format",
           })
           .transform((val) => {
-            // Date-only strings parse as UTC midnight; append local time to avoid -1 day shift
+            // Transaction dates are calendar dates.
+            // Store date-only values at UTC midnight so they are
+            // independent of the server/container/browser timezone.
             if (/^\d{4}-\d{2}-\d{2}$/.test(val)) {
-              return new Date(val + "T00:00:00")
+              return new Date(`${val}T00:00:00.000Z`)
             }
             return new Date(val)
           }),

--- a/models/transactions.ts
+++ b/models/transactions.ts
@@ -65,8 +65,8 @@ export const getTransactions = cache(
 
       if (filters.dateFrom || filters.dateTo) {
         where.issuedAt = {
-          gte: filters.dateFrom ? new Date(filters.dateFrom) : undefined,
-          lte: filters.dateTo ? new Date(filters.dateTo) : undefined,
+          gte: filters.dateFrom ? new Date(`${filters.dateFrom}T00:00:00.000Z`) : undefined,
+          lte: filters.dateTo ? new Date(`${filters.dateTo}T23:59:59.999Z`) : undefined,
         }
       }
 


### PR DESCRIPTION
<html>
<body>
<h1>Summary</h1><p>Fixed transaction dates displaying <strong>one day earlier</strong> in timezones behind UTC.</p><h2>Root Cause</h2><p>Transaction dates were being interpreted inconsistently between UTC and local time. This caused a date such as <code inline="">2026-07-25</code> to be displayed as <code inline="">2026-07-24</code> in UTC-negative timezones.</p><h2>Solution</h2><p>Treat transaction dates consistently as <strong>UTC calendar dates</strong> across storage, editing, display, and filtering.</p><h3>Required Files</h3><ul><li><p><code inline="">forms/transactions.ts</code></p></li><li><p><code inline="">components/transactions/edit.tsx</code></p></li><li><p><code inline="">components/transactions/list.tsx</code></p></li><li><p><code inline="">models/transactions.ts</code></p></li></ul><hr><h2>Changes</h2><h3>1. <code inline="">forms/transactions.ts</code></h3><p><strong>Previous:</strong></p><pre><code class="language-ts">return new Date(val + "T00:00:00")
</code></pre><p><strong>Updated:</strong></p><pre><code class="language-ts">return new Date(`${val}T00:00:00.000Z`)
</code></pre><p><strong>Result:</strong></p><pre><code class="language-text">Input:    2026-07-25
Stored:   2026-07-25T00:00:00.000Z
</code></pre><p>The explicit <code inline="">Z</code> ensures the date is interpreted as UTC rather than local time.</p><hr><h3>2. <code inline="">components/transactions/edit.tsx</code></h3><p><strong>Previous:</strong></p><pre><code class="language-ts">transaction.issuedAt
    ? format(transaction.issuedAt, "yyyy-MM-dd")
    : ""
</code></pre><p><strong>Updated:</strong></p><pre><code class="language-ts">transaction.issuedAt
    ? transaction.issuedAt.toISOString().slice(0, 10)
    : ""
</code></pre><p><strong>Result:</strong></p><pre><code class="language-text">Database:  2026-07-25T00:00:00.000Z
Date field: 2026-07-25
</code></pre><p>This prevents the edit form from converting the timestamp to local time.</p><hr><h3>3. <code inline="">components/transactions/list.tsx</code></h3><p><strong>Previous:</strong></p><pre><code class="language-ts">formatValue: (transaction: Transaction) =&gt;
    transaction.issuedAt
        ? formatDate(transaction.issuedAt, "yyyy-MM-dd")
        : ""
</code></pre><p><strong>Updated:</strong></p><pre><code class="language-ts">formatValue: (transaction: Transaction) =&gt;
    transaction.issuedAt
        ? transaction.issuedAt.toISOString().slice(0, 10)
        : ""
</code></pre><p><strong>Result:</strong></p><pre><code class="language-text">Database:       2026-07-25T00:00:00.000Z
Transaction UI: 2026-07-25
</code></pre><p>This fixes the remaining UI issue where the transaction list displayed the previous day while the date selector showed the correct date.</p><p>The unused import can also be removed:</p><pre><code class="language-ts">import { formatDate } from "date-fns"
</code></pre><hr><h3>4. <code inline="">models/transactions.ts</code></h3><p><strong>Previous:</strong></p><pre><code class="language-ts">gte: filters.dateFrom
    ? new Date(filters.dateFrom)
    : undefined,

lte: filters.dateTo
    ? new Date(filters.dateTo)
    : undefined,
</code></pre><p><strong>Updated:</strong></p><pre><code class="language-ts">gte: filters.dateFrom
    ? new Date(`${filters.dateFrom}T00:00:00.000Z`)
    : undefined,

lte: filters.dateTo
    ? new Date(`${filters.dateTo}T23:59:59.999Z`)
    : undefined,
</code></pre><p><strong>Result:</strong></p><p>For a filter of:</p><pre><code class="language-text">From: 2026-07-25
To:   2026-07-25
</code></pre><p>the query searches:</p><pre><code class="language-text">2026-07-25T00:00:00.000Z
        →
2026-07-25T23:59:59.999Z
</code></pre><p>This ensures the entire selected calendar day is included.</p><hr><h2>Test Plan</h2><p>Create a transaction dated <strong>2026-07-25</strong> and verify:</p>
Test | Expected
-- | --
Create transaction | 2026-07-25
Transaction list | 2026-07-25
Edit date selector | 2026-07-25
Save after editing | 2026-07-25
Browser/page reload | 2026-07-25
Filter 07/25 → 07/25 | Transaction appears
UTC-negative timezone | No date shift

<h2>Expected End State</h2><p>A transaction entered as:</p><pre><code class="language-text">2026-07-25
</code></pre><p>should consistently remain:</p><pre><code class="language-text">2026-07-25
</code></pre><p>through <strong>creation → database → list → edit → filtering</strong>, regardless of the server or user's timezone.<br></p></body></html><!--EndFragment-->
</body>
</html>